### PR TITLE
明細で商品選択時に単位が自動挿入されるように変更

### DIFF
--- a/app/static/invoice.html
+++ b/app/static/invoice.html
@@ -494,6 +494,7 @@
                 itemSelect(record) {
                     Vue.set(self.invoiceItem, 'itemId', record.id);
                     Vue.set(self.invoiceItem, 'itemName', record.itemName);
+                    Vue.set(self.invoiceItem, 'unit', record.unit);
                     Vue.set(self.invoiceItem, 'price', record.basePrice);
                     Vue.set(self.invoiceItem, 'cost', record.baseCost);
                     this.$refs['items-modal'].hide()
@@ -531,7 +532,7 @@
             computed: {
                 // 逐次、数量＊単価の合計をする
                 sum: function () {
-                    if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 }　//初期立ち上がりでのエラー抑制
+                    if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
                     return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * invoice_item.price)).reduce(function (a, b) { return a + b }, 0);
                 },
                 // 得意先選択モーダルの検索機能

--- a/app/static/invoice_dust.html
+++ b/app/static/invoice_dust.html
@@ -474,6 +474,7 @@
                 itemSelect(record) {
                     Vue.set(self.invoiceItem, 'itemId', record.id);
                     Vue.set(self.invoiceItem, 'itemName', record.itemName);
+                    Vue.set(self.invoiceItem, 'unit', record.unit);
                     Vue.set(self.invoiceItem, 'price', record.basePrice);
                     Vue.set(self.invoiceItem, 'cost', record.baseCost);
                     this.$refs['items-modal'].hide()
@@ -497,7 +498,7 @@
             computed: {
                 // 逐次、数量＊単価の合計をする
                 sum: function () {
-                    if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 }　//初期立ち上がりでのエラー抑制
+                    if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
                     return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * invoice_item.price)).reduce(function (a, b) { return a + b }, 0);
                 },
                 // 得意先選択モーダルの検索機能

--- a/app/static/item.html
+++ b/app/static/item.html
@@ -141,7 +141,7 @@
                             <b-col>
                                 <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単位"
                                     label-for="unit">
-                                    <b-form-input v-model="item.unit" id="unit" size="sm"></b-form-input>
+                                    <b-form-select v-model="item.unit" :options="units" size="sm"></b-form-select>
                                 </b-form-group>
                                 <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
                                     label-for="メモ">
@@ -181,6 +181,7 @@
                 pageName: 'index',
                 items: [],               //全件item
                 item: [],                //選択中のitem
+                units: [],
             },
             methods: {
                 // ---Items---
@@ -254,6 +255,14 @@
                     if (!item || type !== 'row') return
                     if (!item.id) return "d-none";
                 },
+                getUnits: async function () {
+                    self = this;
+                    await axios.get("/units")
+                        .then(function (response) {
+                            console.log(response);
+                            self.units = response.data.map(item => item['unitName']);
+                        });
+                },
                 toast(toaster, append = false) {
                     this.$bvToast.toast(`${toaster}`, {
                         title: `確認`,
@@ -269,6 +278,7 @@
             },
             mounted: function () {
                 this.getItems();
+                this.getUnits();
             },
         })
 

--- a/app/static/quotation.html
+++ b/app/static/quotation.html
@@ -490,6 +490,7 @@
                 itemSelect(record) {
                     Vue.set(self.quotationItem, 'itemId', record.id);
                     Vue.set(self.quotationItem, 'itemName', record.itemName);
+                    Vue.set(self.quotationItem, 'unit', record.unit);
                     Vue.set(self.quotationItem, 'price', record.basePrice);
                     Vue.set(self.quotationItem, 'cost', record.baseCost);
                     this.$refs['items-modal'].hide()
@@ -513,7 +514,7 @@
             computed: {
                 // 逐次、数量＊単価の合計をする
                 sum: function () {
-                    if (typeof (this.quotation.quotation_items) == 'undefined') { return 0 }　//初期立ち上がりでのエラー抑制
+                    if (typeof (this.quotation.quotation_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
                     return this.quotation.quotation_items.map(quotation_item => parseInt(quotation_item.count * quotation_item.price)).reduce(function (a, b) { return a + b }, 0);
                 },
                 // 得意先選択モーダルの検索機能

--- a/app/static/quotation_dust.html
+++ b/app/static/quotation_dust.html
@@ -474,6 +474,7 @@
                 itemSelect(record) {
                     Vue.set(self.quotationItem, 'itemId', record.id);
                     Vue.set(self.quotationItem, 'itemName', record.itemName);
+                    Vue.set(self.quotationItem, 'unit', record.unit);
                     Vue.set(self.quotationItem, 'price', record.basePrice);
                     Vue.set(self.quotationItem, 'cost', record.baseCost);
                     this.$refs['items-modal'].hide()
@@ -497,7 +498,7 @@
             computed: {
                 // 逐次、数量＊単価の合計をする
                 sum: function () {
-                    if (typeof (this.quotation.quotation_items) == 'undefined') { return 0 }　//初期立ち上がりでのエラー抑制
+                    if (typeof (this.quotation.quotation_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
                     return this.quotation.quotation_items.map(quotation_item => parseInt(quotation_item.count * quotation_item.price)).reduce(function (a, b) { return a + b }, 0);
                 },
                 // 得意先選択モーダルの検索機能


### PR DESCRIPTION
- 商品ページ登録・更新時に、登録されている単位をセレクトボックスで選択できるようにした。
- 請求書・見積書ページの明細にて、商品を選択時に単位が自動挿入されるようにした。
- 要らないと思うが一応、削除済み請求書・削除済み見積書ページにも上記の変更を適用。