### PR TITLE
デザイン指摘箇所修正。全体に適用。

### DIFF
--- a/app/static/category.html
+++ b/app/static/category.html
@@ -178,13 +178,28 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <router-link to="?page=index">
-                    <b-button variant="info" class="mr-3" @click="bulkUpsert(category);">適用
-                    </b-button>
-                </router-link>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <router-link to="?page=index">
+                    <b-button variant="success" @click="bulkUpsert(category);hideUpsertModal();">はい
+                </router-link>
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -211,11 +226,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertCategory(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateCategory(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertCategory: async function (item) {
@@ -272,19 +285,17 @@
                     if (!item || type !== 'row') return
                     if (!item.id) return "d-none";
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 showDeleteModal() {
                     this.$refs['deleteModal'].show()
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
             },
             mounted: function () {

--- a/app/static/customer.html
+++ b/app/static/customer.html
@@ -224,13 +224,28 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <router-link to="?page=index">
-                    <b-button variant="info" class="mr-3" @click="bulkUpsert(customer);">適用
-                    </b-button>
-                </router-link>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <router-link to="?page=index">
+                    <b-button variant="success" @click="bulkUpsert(customer);hideUpsertModal();">はい
+                </router-link>
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -257,11 +272,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertCustomer(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateCustomer(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertCustomer: async function (item) {
@@ -318,19 +331,17 @@
                     if (!item || type !== 'row') return
                     if (!item.id) return "d-none";
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 showDeleteModal() {
                     this.$refs['deleteModal'].show()
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
             },
             mounted: function () {

--- a/app/static/invoice.html
+++ b/app/static/invoice.html
@@ -234,28 +234,40 @@
                                 v-on:keydown.enter="selectInvoiceItem(data.item);onKeyDownItem();">
                             </b-form-textarea>
 
-                            <b-modal size="xl" ref="items-modal">
+                            <b-modal size="xl" ref="items-modal" title="商品一覧">
                                 <b-row>
-                                    <b-col class="text-center">
-                                        <p>商品を選択してください</p>
+                                    <b-col>
                                     </b-col>
                                     <b-col>
-                                        <b-form-group label-cols="4" label-size="sm" label-align="center"
-                                            label-for="searchItemWord" label-class="fas fa-search">
-                                            <b-form-input v-model="searchItemWord" id="searchItemWord" size="sm">
-                                            </b-form-input>
-                                        </b-form-group>
-                                        <b-form-group label-cols="4" label-size="sm" label-align="center" label="カテゴリ"
-                                            label-for="searchItemSelectCategory">
-                                            <b-form-select v-model="searchItemSelectCategory" :options="categories"
-                                                size="sm">
-                                            </b-form-select>
-                                        </b-form-group>
-                                        <b-form-group label-cols="4" label-size="sm" label-align="center" label="メーカー"
-                                            label-for="searchItemSelectMaker">
-                                            <b-form-select v-model="searchItemSelectMaker" :options="makers" size="sm">
-                                            </b-form-select>
-                                        </b-form-group>
+                                        <b-row class="mb-1">
+                                            <b-col cols="4" class="text-center">
+                                                <label for="searchItemWord"><i class="fas fa-search"></i></label>
+                                            </b-col>
+                                            <b-col cols="8">
+                                                <b-form-input v-model="searchItemWord" id="searchItemWord" size="sm">
+                                                </b-form-input>
+                                            </b-col>
+                                        </b-row>
+                                        <b-row class="mb-1">
+                                            <b-col cols="4" class="text-center">
+                                                <label for="searchItemSelectCategory">カテゴリ</label>
+                                            </b-col>
+                                            <b-col cols="8">
+                                                <b-form-select v-model="searchItemSelectCategory" :options="categories"
+                                                    size="sm">
+                                                </b-form-select>
+                                            </b-col>
+                                        </b-row>
+                                        <b-row class="mb-2">
+                                            <b-col cols="4" class="text-center">
+                                                <label for="searchItemSelectMaker">メーカー</label>
+                                            </b-col>
+                                            <b-col cols="8">
+                                                <b-form-select v-model="searchItemSelectMaker" :options="makers"
+                                                    size="sm">
+                                                </b-form-select>
+                                            </b-col>
+                                        </b-row>
                                     </b-col>
                                 </b-row>
                                 <b-table hover striped small sort-by="ID" id="items-table" :items="searchItems"
@@ -366,14 +378,26 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <b-button pill variant="info" class="mr-3" @click="bulkUpsert(invoice);changeMode('index');" id="upsert"
-                    size="lg"><i class="far fa-save"></i></b-button>
-                <b-tooltip target="upsert" title="適用"></b-tooltip>
-                <b-button pill variant="info" @click="pdfout" id="pdfout" size="lg"><i class="fas fa-print"></i>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
                 </b-button>
-                <b-tooltip target="pdfout" title="印刷"></b-tooltip>
+                <b-button pill variant="info" @click="pdfout" id="pdfout"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <b-button variant="success" @click="bulkUpsert(invoice);hideUpsertModal();changeMode('index');">はい
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -412,11 +436,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertInvoice(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateInvoice(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertInvoice: async function (item) {
@@ -537,14 +559,6 @@
                             self.makers.unshift('')
                         });
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 // ページ変更
                 changeMode(pageName) {
                     this.pageName = pageName;
@@ -554,6 +568,12 @@
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
                 // 顧客名モーダル選択時
                 customerSelect(record) {

--- a/app/static/invoice_dust.html
+++ b/app/static/invoice_dust.html
@@ -273,7 +273,8 @@
         <!-- 更新・取消ボタンのフッター -->
         <b-card v-if="pageName=='show'" bg-variant="dark" text-variant="white" class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" size="lg" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                </b-button>
             </div>
         </b-card>
 

--- a/app/static/item.html
+++ b/app/static/item.html
@@ -221,13 +221,28 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <router-link to="?page=index">
-                    <b-button variant="info" class="mr-3" @click="bulkUpsert(item);">適用
-                    </b-button>
-                </router-link>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <router-link to="?page=index">
+                    <b-button variant="success" @click="bulkUpsert(item);hideUpsertModal();">はい
+                </router-link>
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -257,11 +272,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertItem(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateItem(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertItem: async function (item) {
@@ -342,19 +355,17 @@
                             self.makers = response.data.map(item => item['makerName'])
                         });
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 showDeleteModal() {
                     this.$refs['deleteModal'].show()
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
             },
             mounted: function () {

--- a/app/static/maker.html
+++ b/app/static/maker.html
@@ -178,13 +178,28 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <router-link to="?page=index">
-                    <b-button variant="info" class="mr-3" @click="bulkUpsert(maker);">適用
-                    </b-button>
-                </router-link>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <router-link to="?page=index">
+                    <b-button variant="success" @click="bulkUpsert(maker);hideUpsertModal();">はい
+                </router-link>
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -211,11 +226,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertMaker(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateMaker(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertMaker: async function (item) {
@@ -272,19 +285,17 @@
                     if (!item || type !== 'row') return
                     if (!item.id) return "d-none";
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 showDeleteModal() {
                     this.$refs['deleteModal'].show()
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
             },
             mounted: function () {

--- a/app/static/memo.html
+++ b/app/static/memo.html
@@ -174,14 +174,28 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <router-link to="?page=index">
-                    <b-button variant="info" class="mr-3" @click="bulkUpsert(memo);">適用
-                    </b-button>
-                </router-link>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
-        </style>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <router-link to="?page=index">
+                    <b-button variant="success" @click="bulkUpsert(memo);hideUpsertModal();">はい
+                </router-link>
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -208,11 +222,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertMemo(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateMemo(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertMemo: async function (item) {
@@ -269,19 +281,17 @@
                     if (!item || type !== 'row') return
                     if (!item.id) return "d-none";
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 showDeleteModal() {
                     this.$refs['deleteModal'].show()
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
             },
             mounted: function () {

--- a/app/static/quotation.html
+++ b/app/static/quotation.html
@@ -234,28 +234,40 @@
                                 v-on:keydown.enter="selectQuotationItem(data.item);onKeyDownItem();">
                             </b-form-textarea>
 
-                            <b-modal size="xl" ref="items-modal">
+                            <b-modal size="xl" ref="items-modal" title="商品一覧">
                                 <b-row>
-                                    <b-col class="text-center">
-                                        <p>商品を選択してください</p>
+                                    <b-col>
                                     </b-col>
                                     <b-col>
-                                        <b-form-group label-cols="2" label-size="sm" label-align="center"
-                                            label-for="searchItemWord" label-class="fas fa-search">
-                                            <b-form-input v-model="searchItemWord" id="searchItemWord" size="sm">
-                                            </b-form-input>
-                                        </b-form-group>
-                                        <b-form-group label-cols="2" label-size="sm" label-align="center" label="カテゴリ"
-                                            label-for="searchItemSelectCategory">
-                                            <b-form-select v-model="searchItemSelectCategory" :options="categories"
-                                                size="sm">
-                                            </b-form-select>
-                                        </b-form-group>
-                                        <b-form-group label-cols="2" label-size="sm" label-align="center" label="メーカー"
-                                            label-for="searchItemSelectMaker">
-                                            <b-form-select v-model="searchItemSelectMaker" :options="makers" size="sm">
-                                            </b-form-select>
-                                        </b-form-group>
+                                        <b-row class="mb-1">
+                                            <b-col cols="4" class="text-center">
+                                                <label for="searchItemWord"><i class="fas fa-search"></i></label>
+                                            </b-col>
+                                            <b-col cols="8">
+                                                <b-form-input v-model="searchItemWord" id="searchItemWord" size="sm">
+                                                </b-form-input>
+                                            </b-col>
+                                        </b-row>
+                                        <b-row class="mb-1">
+                                            <b-col cols="4" class="text-center">
+                                                <label for="searchItemSelectCategory">カテゴリ</label>
+                                            </b-col>
+                                            <b-col cols="8">
+                                                <b-form-select v-model="searchItemSelectCategory" :options="categories"
+                                                    size="sm">
+                                                </b-form-select>
+                                            </b-col>
+                                        </b-row>
+                                        <b-row class="mb-2">
+                                            <b-col cols="4" class="text-center">
+                                                <label for="searchItemSelectMaker">メーカー</label>
+                                            </b-col>
+                                            <b-col cols="8">
+                                                <b-form-select v-model="searchItemSelectMaker" :options="makers"
+                                                    size="sm">
+                                                </b-form-select>
+                                            </b-col>
+                                        </b-row>
                                     </b-col>
                                 </b-row>
                                 <b-table hover striped small sort-by="ID" id="items-table" :items="searchItems"
@@ -366,10 +378,26 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <b-button variant="info" class="mr-3" @click="bulkUpsert(quotation);changeMode('index');">適用</b-button>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <b-button variant="success" @click="bulkUpsert(quotation);hideUpsertModal();changeMode('index');">はい
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -408,11 +436,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertQuotation(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateQuotation(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertQuotation: async function (item) {
@@ -533,14 +559,6 @@
                             self.makers.unshift('')
                         });
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 // ページ変更
                 changeMode(pageName) {
                     this.pageName = pageName;
@@ -550,6 +568,12 @@
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
                 // 顧客名モーダル選択時
                 customerSelect(record) {

--- a/app/static/quotation_dust.html
+++ b/app/static/quotation_dust.html
@@ -273,7 +273,8 @@
         <!-- 更新・取消ボタンのフッター -->
         <b-card v-if="pageName=='show'" bg-variant="dark" text-variant="white" class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" size="lg" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                </b-button>
             </div>
         </b-card>
 

--- a/app/static/unit.html
+++ b/app/static/unit.html
@@ -174,12 +174,28 @@
         <b-card v-if="pageName=='show' || pageName=='store'" bg-variant="dark" text-variant="white"
             class="fixed-bottom footer">
             <div class="d-flex justify-content-end">
-                <router-link to="?page=index">
-                    <b-button variant="info" class="mr-3" @click="bulkUpsert(unit)">適用</b-button>
-                </router-link>
-                <b-button variant="info" @click="alert('印刷しました。')">印刷</b-button>
+                <b-button pill variant="info" class="mr-3" @click="showUpsertModal();" id="showUpsertModal">適用
+                </b-button>
+                <b-button pill variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i></b-button>
             </div>
         </b-card>
+
+        <!-- 保存モーダル -->
+        <b-modal ref="upsertModal" hide-footer>
+            <div class="d-block text-center">
+                <h3>保存しますか？</h3>
+            </div>
+            <b-row>
+                <b-col></b-col>
+                <router-link to="?page=index">
+                    <b-button variant="success" @click="bulkUpsert(unit);hideUpsertModal();">はい
+                </router-link>
+                </b-button>
+                <b-col></b-col>
+                <b-button @click="hideUpsertModal();">いいえ</b-button>
+                <b-col></b-col>
+            </b-row>
+        </b-modal>
 
     </div>
 
@@ -206,11 +222,9 @@
                 bulkUpsert(item) {
                     if (!item.id) {
                         this.insertUnit(item);
-                        this.toast("新規作成しました");
                     }
                     else {
                         this.updateUnit(item);
-                        this.toast("更新しました");
                     }
                 },
                 insertUnit: async function (item) {
@@ -267,19 +281,17 @@
                     if (!item || type !== 'row') return
                     if (!item.id) return "d-none";
                 },
-                toast(toaster, append = false) {
-                    this.$bvToast.toast(`${toaster}`, {
-                        title: `確認`,
-                        toaster: 'b-toaster-top-right',
-                        solid: true,
-                        appendToast: append,
-                    })
-                },
                 showDeleteModal() {
                     this.$refs['deleteModal'].show()
                 },
                 hideDeleteModal() {
                     this.$refs['deleteModal'].hide()
+                },
+                showUpsertModal() {
+                    this.$refs['upsertModal'].show();
+                },
+                hideUpsertModal() {
+                    this.$refs['upsertModal'].hide();
                 },
             },
             mounted: function () {


### PR DESCRIPTION
- 請求書・見積書の商品選択モーダルデザイン修正
- 新規作成・更新の「適用」押下時、トースト表示から確認モーダルに変更
- アイコン表示のボタンにはポッパーはやっぱり要らないとの事なので、戻す。