### PR TITLE
明細がデフォルトで５行表示されるように修正

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,10 +5,6 @@ import json
 from datetime import date
 
 
-#@app.route('/')
-#def index():
-#    return 'HelloWorld!'
-
 
 # -----ユーザー(Users)-----
 @app.route('/users', methods=['GET'])
@@ -219,19 +215,20 @@ def invoice_show(id):
 @app.route('/invoice', methods=['POST'])
 def invoice_create():
     data = request.json
+    newInvoiceItems = []
 
     if data.get('invoice_items'):
-        newInvoiceItems = [
-            Invoice_Item(
-                invoiceId=item.get('invoiceId'),
-                itemId=item.get('itemId'),
-                price=item.get('price'),
-                count=item.get('count'),
-                unit=item.get('unit'),
-                itemName=item.get('itemName'),
-            )
-            for item in data.get('invoice_items')
-        ]
+        for item in data.get('invoice_items'):
+            existItems = {k: v for k, v in item.items() if v is not None}
+            if any(existItems):
+                newInvoiceItems.append(Invoice_Item(
+                    invoiceId=existItems.get('invoiceId'),
+                    itemId=existItems.get('itemId'),
+                    price=existItems.get('price'),
+                    count=existItems.get('count'),
+                    unit=existItems.get('unit'),
+                    itemName=existItems.get('itemName'),
+                ))
     else:
         newInvoiceItems = []
 
@@ -396,19 +393,20 @@ def quotation_show(id):
 @app.route('/quotation', methods=['POST'])
 def quotation_create():
     data = request.json
+    newQuotationItems = []
 
     if data.get('quotation_items'):
-        newQuotationItems = [
-            Quotation_Item(
-                quotationId=item.get('quotationId'),
-                itemId=item.get('itemId'),
-                price=item.get('price'),
-                count=item.get('count'),
-                unit=item.get('unit'),
-                itemName=item.get('itemName'),
-            )
-            for item in data.get('quotation_items')
-        ]
+        for item in data.get('quotation_items'):
+            existItems = {k: v for k, v in item.items() if v is not None}
+            if any(existItems):
+                newQuotationItems.append(Quotation_Item(
+                    quotationId=existItems.get('quotationId'),
+                    itemId=existItems.get('itemId'),
+                    price=existItems.get('price'),
+                    count=existItems.get('count'),
+                    unit=existItems.get('unit'),
+                    itemName=existItems.get('itemName'),
+                ))
     else:
         newQuotationItems = []
 

--- a/app/static/invoice.html
+++ b/app/static/invoice.html
@@ -436,7 +436,7 @@
                     self = this;
                     self.invoices.push({
                         isInsert: true,
-                        invoice_items: [],
+                        invoice_items: [{}, {}, {}, {}, {}],
                     });
                     self.invoice = self.invoices.slice(-1)[0];
                     localStorage.setItem('invoice', JSON.stringify(self.invoice));

--- a/app/static/quotation.html
+++ b/app/static/quotation.html
@@ -436,7 +436,7 @@
                     self = this;
                     self.quotations.push({
                         isInsert: true,
-                        quotation_items: [],
+                        quotation_items: [{}, {}, {}, {}, {}],
                     });
                     self.quotation = self.quotations.slice(-1)[0];
                     localStorage.setItem('quotation', JSON.stringify(self.quotation));


### PR DESCRIPTION
こっちのブランチを先にレビューして欲しい。

見積・請求の新規作成時に明細をデフォルトで５行分表示するようにしたのだが、全フィールド記入なしのレコードはInsert時にDB側のレコードを作成しないようにAPIを変更してみた。
しかしながら、2重forループが発生してしまうのでこれが悪手であればこのプルリクは破棄してしまおう。