### PR TITLE
既存のユニットテスト修正

### DIFF
--- a/app/test_customer.py
+++ b/app/test_customer.py
@@ -1,0 +1,94 @@
+from logging import captureWarnings
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_costomers(self):
+        print('---Customer全件読み込み---')
+        customers = Customer.query.all()
+        c_count = len(customers)
+        self.assertTrue(c_count)
+        # Invoice_Itemまで全件取得
+        print('Customer→Invoice_Item全件取得')
+        invoiceItemCount = 0
+        quotationItemCount = 0
+        for customer in customers:
+            for invoice in customer.invoices:
+                for invoiceItem in invoice.invoice_items:
+                    invoiceItemCount += 1
+        self.assertGreaterEqual(invoiceItemCount, 1)
+        print('Customer→Quotation_Item全件取得')
+        for customer in customers:
+            for quotation in customer.quotations:
+                for quotationItem in quotation.quotation_items:
+                    quotationItemCount += 1
+        self.assertGreaterEqual(quotationItemCount, 1)
+
+    def test_get_customers_dict(self):
+        print('---Customer全件読み込み→Dict---')
+        customers = Customer.query.all()
+        sch = CustomerSchema(many=True).dump(customers)
+        self.assertEqual(sch[0]['customerName'], '○○株式会社')
+
+    def test_get_customer_byId(self):
+        print('---Customer一件読み込み---')
+        customer = Customer.query.filter(Customer.id == 1).first()
+        self.assertTrue(customer)
+        self.assertEqual(customer.customerName, '○○株式会社')
+
+        print('---Customer一件読み込み失敗---')
+        customers = Customer.query.filter(Customer.id == 9999).all()
+        self.assertFalse(customers)
+        self.assertEqual(len(customers), 0)
+
+    def test_update_customer(self):
+        print('---Customer一件更新---')
+        customer = Customer.query.filter(Customer.id == 2).first()
+        customer.customerName = 'テスト株式会社'
+        db.session.commit()
+        customer = Customer.query.filter(Customer.id == 2).first()
+        self.assertEqual(customer.customerName, "テスト株式会社")
+
+    def test_create_customer(self):
+        print('---Customer新規作成---')
+        customers = [
+            Customer(customerName='テストクリエイト株式会社', honorificTitle='御中', postNumber='000-0000', address='鹿沼市板荷000', telNumber='000-0000-0000',
+                     faxNumber='000-0000-0000', url='example.com', email='example@co.jp', manager='田中太郎', representative='田中代表', memo='これは○○株式会社のメモです'),
+            Customer(customerName='テストクリエイト株式会社2', honorificTitle='御中', postNumber='000-0000', address='鹿沼市板荷000', telNumber='000-0000-0000',
+                     faxNumber='000-0000-0000', url='example.com', email='example@co.jp', manager='田中太郎', representative='田中代表', memo='これは○○株式会社のメモです'),
+        ]
+        db.session.add_all(customers)
+        db.session.commit()
+        self.assertGreaterEqual(len(Customer.query.all()), 2)
+
+    def test_delete_customer(self):
+        print('---Customer一件削除---')
+        customer = Customer(customerName='デリートテスト会社', honorificTitle='御中', postNumber='000-0000', address='鹿沼市板荷000', telNumber='000-0000-0000',
+                            faxNumber='000-0000-0000', url='example.com', email='example@co.jp', manager='田中太郎', representative='田中代表', memo='これは○○株式会社のメモです')
+        db.session.add(customer)
+        db.session.commit()
+        newId = customer.id
+        customer = Customer.query.filter(Customer.id == newId).delete()
+        db.session.commit()
+
+        customer = Customer.query.filter(Customer.id == newId).all()
+        self.assertEqual(len(customer), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_invoice.py
+++ b/app/test_invoice.py
@@ -1,0 +1,94 @@
+from app import db, app
+from models import *
+import unittest
+from datetime import datetime
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_invoices(self):
+        print('---Invoice全件読み込み---')
+        invoices = Invoice.query.all()
+        invoiceCount = len(invoices)
+        self.assertTrue(invoiceCount)
+        # customerまで全件取得
+        print('Invoice→Customer全件読込')
+        customerCount = 0
+        for invoice in invoices:
+            if(invoice.customer is not None):
+                customerCount += 1
+        self.assertGreaterEqual(customerCount, 1)
+
+        # Invoice_Itemまで取得
+        print('Invoice→Invoice_Item全件取得')
+        invoiceItemCount = 0
+        for invoice in invoices:
+            for invoiceItem in invoice.invoice_items:
+                invoiceItemCount += 1
+        self.assertGreaterEqual(invoiceItemCount, 1)
+
+    def test_get_invoices_dict(self):
+        print('---Invoice全件読込→Dict---')
+        invoices = Invoice.query.all()
+        sch = InvoiceSchema(many=True).dump(invoices)
+        self.assertEqual(sch[0]['title'], '○○株式会社への請求書')
+
+    def test_get_invoice_byId(self):
+        print('---Invoice一件読み込み---')
+        invoice = Invoice.query.filter(Invoice.id == 1).first()
+        self.assertTrue(invoice)
+        self.assertEqual(invoice.title, '○○株式会社への請求書')
+
+        print('---Invoice一件読み込み失敗---')
+        invoices = Invoice.query.filter(Invoice.id == 9999).all()
+        self.assertFalse(invoices)
+        self.assertEqual(len(invoices), 0)
+
+    def test_update_invoice(self):
+        print('---Invoice一件更新---')
+        invoice = Invoice.query.filter(Invoice.id == 2).first()
+        invoice.title = '××株式会社への請求書'
+        db.session.commit()
+        invoice = Invoice.query.filter(Invoice.id == 2).first()
+        self.assertEqual(invoice.title, "××株式会社への請求書")
+
+    def test_create_invoice(self):
+        print('---Invoice新規作成---')
+        invoices = [
+            Invoice(customerId=1, customerName='○○建設', applyNumber=1000004, applyDate=datetime.now(), deadLine=datetime.now(),
+                    title='○○建設への請求書', memo='これは請求書のメモです', remarks='これは請求書の備考です', isTaxExp=True, isDelete=False),
+            Invoice(customerId=1, customerName='○○商店', applyNumber=1000005, applyDate=datetime.now(), deadLine=datetime.now(),
+                    title='○○商店への請求書', memo='これは請求書のメモです', remarks='これは請求書の備考です', isTaxExp=True, isDelete=False),
+        ]
+        db.session.add_all(invoices)
+        db.session.commit()
+        self.assertGreaterEqual(len(Invoice.query.all()), 2)
+
+    def test_delete_invoice(self):
+        print('---Invoice一件削除---')
+        invoice = Invoice(customerId=1, customerName='テスト会社', applyNumber=1000006, applyDate=datetime.now(), deadLine=datetime.now(),
+                          title='デリートテスト会社への請求書', memo='これは請求書のメモです', remarks='これは請求書の備考です', isTaxExp=True, isDelete=False)
+        db.session.add(invoice)
+        db.session.commit()
+        newId = invoice.id
+        invoice = Invoice.query.filter(Invoice.id == newId).delete()
+        db.session.commit()
+
+        invoice = Invoice.query.filter(Invoice.id == newId).all()
+        self.assertEqual(len(invoice), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_invoice_item.py
+++ b/app/test_invoice_item.py
@@ -1,0 +1,85 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_invoice_items(self):
+        print('---Invoice_Item全件読み込み---')
+        invoiceItems = Invoice_Item.query.all()
+        invoiceItemCount = len(invoiceItems)
+        self.assertTrue(invoiceItemCount)
+        print('---Invoice_Item→Customer全件取得---')
+        customerCount = 0
+        for invoiceItem in invoiceItems:
+            if invoiceItem.invoice.customer is not None:
+                customerCount += 1
+        self.assertGreaterEqual(customerCount, 1)
+
+    def test_get_invoice_items_dict(self):
+        print('---InvoiceItem全件取得→Dict---')
+        invoiceItems = Invoice_Item.query.all()
+        sch = Invoice_ItemSchema(many=True).dump(invoiceItems)
+        self.assertEqual(sch[0]['price'], 100)
+
+    def test_get_invoice_item_byId(self):
+        print('---Invoice_Item一件読み込み---')
+        invoiceItem = Invoice_Item.query.filter(Invoice_Item.id == 1).first()
+        self.assertTrue(invoiceItem)
+        self.assertEqual(invoiceItem.count, 5)
+
+        print('---Invoice_Item一件読み込み失敗---')
+        invoiceItems = Invoice_Item.query.filter(Invoice_Item.id == 9999).all()
+        self.assertFalse(invoiceItems)
+        self.assertEqual(len(invoiceItems), 0)
+
+    def test_update_invoice_item(self):
+        print('---Invoice_Item一件更新---')
+        invoiceItem = Invoice_Item.query.filter(Invoice_Item.id == 2).first()
+        invoiceItem.count = 20
+        db.session.commit()
+        invoiceItem = Invoice_Item.query.filter(Invoice_Item.id == 2).first()
+        self.assertEqual(invoiceItem.count, 20)
+
+    def test_create_invoice_item(self):
+        print('---Invoice_Item新規作成---')
+        invoiceItems = [
+            Invoice_Item(invoiceId=3, itemId=2, itemName='鉛筆',
+                         price=100, cost=20, count=20, unit='本'),
+            Invoice_Item(invoiceId=3, itemId=3, itemName='ラジオ',
+                         price=200, cost=100, count=10, unit='台'),
+        ]
+        db.session.add_all(invoiceItems)
+        db.session.commit()
+        self.assertGreaterEqual(len(Invoice_Item.query.all()), 2)
+
+    def test_delete_invoice_item(self):
+        print('---Invoice_Item一件削除---')
+        invoiceItem = Invoice_Item(
+            invoiceId=1, itemId=1, itemName='りんご', price=999, cost=100, count=10, unit='個')
+        db.session.add(invoiceItem)
+        db.session.commit()
+        newId = invoiceItem.id
+        invoiceItem = Invoice_Item.query.filter(
+            Invoice_Item.id == newId).delete()
+        db.session.commit()
+
+        invoiceItem = Invoice_Item.query.filter(Invoice_Item.id == newId).all()
+        self.assertEqual(len(invoiceItem), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_item.py
+++ b/app/test_item.py
@@ -1,0 +1,78 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_items(self):
+        print('---Item全件読み込み---')
+        items = Item.query.all()
+        itemCount = len(items)
+        self.assertTrue(itemCount)
+
+    def test_get_items_dict(self):
+        print('---Item全件読込→Dict---')
+        items = Item.query.all()
+        sch = ItemSchema(many=True).dump(items)
+        self.assertEqual(sch[0]['itemName'], 'りんご')
+
+    def test_get_item_byId(self):
+        print('---Item一件読み込み---')
+        item = Item.query.filter(Item.id == 1).first()
+        self.assertTrue(item)
+        self.assertEqual(item.itemName, 'りんご')
+
+        print('---Item一件読み込み失敗---')
+        items = Item.query.filter(Item.id == 9999).all()
+        self.assertFalse(items)
+        self.assertEqual(len(items), 0)
+
+    def test_update_item(self):
+        print('---Item一件更新---')
+        item = Item.query.filter(Item.id == 2).first()
+        item.itemName = 'ボールペン'
+        db.session.commit()
+        item = Item.query.filter(Item.id == 2).first()
+        self.assertEqual(item.itemName, "ボールペン")
+
+    def test_create_item(self):
+        print('---Item新規作成---')
+        items = [
+            Item(itemName='みかん', itemCode='33333', model='ORG001', category='食料品', maker='○○果樹園', unit='個', basePrice=50,
+                 baseCost=20, memo='これはみかんのメモです'),
+            Item(itemName='ボールペン', itemCode='44444', model='PEN001', category='文具', maker='トンビ鉛筆', unit='本', basePrice=100,
+                 baseCost=10, memo='これはボールペンのメモです'),
+        ]
+        db.session.add_all(items)
+        db.session.commit()
+        self.assertGreaterEqual(len(Item.query.all()), 2)
+
+    def test_delete_item(self):
+        print('---Item一件削除---')
+        item = Item(itemName='ボール', itemCode='55555', model='BAL001', category='玩具', maker='○○スポーツ', unit='個', basePrice=50,
+                    baseCost=20, memo='これはボールのメモです')
+        db.session.add(item)
+        db.session.commit()
+        newId = item.id
+        item = Item.query.filter(Item.id == newId).delete()
+        db.session.commit()
+
+        item = Item.query.filter(Item.id == newId).all()
+        self.assertEqual(len(item), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_memo.py
+++ b/app/test_memo.py
@@ -1,0 +1,75 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_memos(self):
+        print('---Memo全件読み込み---')
+        memos = Memo.query.all()
+        memoCount = len(memos)
+        self.assertTrue(memoCount)
+
+    def test_get_memos_dict(self):
+        print('---Memo全件読込→Dict---')
+        memos = Memo.query.all()
+        sch = MemoSchema(many=True).dump(memos)
+        self.assertEqual(sch[0]['title'], 'メモのタイトル１')
+
+    def test_get_memo_byId(self):
+        print('---Memo一件読み込み---')
+        memo = Memo.query.filter(Memo.id == 1).first()
+        self.assertTrue(memo)
+        self.assertEqual(memo.title, 'メモのタイトル１')
+
+        print('---Memo一件読み込み失敗---')
+        memos = Memo.query.filter(Memo.id == 9999).all()
+        self.assertFalse(memos)
+        self.assertEqual(len(memos), 0)
+
+    def test_update_memo(self):
+        print('---Memo一件更新---')
+        memo = Memo.query.filter(Memo.id == 2).first()
+        memo.title = 'メモのタイトル変更'
+        db.session.commit()
+        memo = Memo.query.filter(Memo.id == 2).first()
+        self.assertEqual(memo.title, "メモのタイトル変更")
+
+    def test_create_memo(self):
+        print('---Memo新規作成---')
+        memos = [
+            Memo(title='メモのタイトル４', content='メモの内容４'),
+            Memo(title='メモのタイトル５', content='メモの内容５'),
+        ]
+        db.session.add_all(memos)
+        db.session.commit()
+        self.assertGreaterEqual(len(Memo.query.all()), 2)
+
+    def test_delete_memo(self):
+        print('---Memo一件削除---')
+        memo = Memo(title='メモのタイトル６', content='メモの内容６')
+        db.session.add(memo)
+        db.session.commit()
+        newId = memo.id
+        memo = Memo.query.filter(Memo.id == newId).delete()
+        db.session.commit()
+
+        memo = Memo.query.filter(Memo.id == newId).all()
+        self.assertEqual(len(memo), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_quotation.py
+++ b/app/test_quotation.py
@@ -1,0 +1,95 @@
+from app import db, app
+from models import *
+import unittest
+from datetime import datetime
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_quotations(self):
+        print('---Quotation全件読み込み---')
+        quotations = Quotation.query.all()
+        quotationCount = len(quotations)
+        self.assertTrue(quotationCount)
+
+        # Customerまで全件取得
+        print('Quotation→Customer全件取得')
+        customerCount = 0
+        for quotation in quotations:
+            if(quotation.customer is not None):
+                customerCount += 1
+        self.assertGreaterEqual(customerCount, 1)
+
+        # Quotation_Itemまで取得
+        print('Quotation→Quotation_Item全件取得')
+        quotationItemCount = 0
+        for quotation in quotations:
+            for quotationItem in quotation.quotation_items:
+                quotationItemCount += 1
+        self.assertGreaterEqual(quotationItemCount, 1)
+
+    def test_get_quotations_dict(self):
+        print('---Quotation全件読込→Dict---')
+        quotations = Quotation.query.all()
+        sch = QuotationSchema(many=True).dump(quotations)
+        self.assertEqual(sch[0]['title'], '○○株式会社への見積書')
+
+    def test_get_quotation_byId(self):
+        print('---Quotation一件読み込み---')
+        quotation = Quotation.query.filter(Quotation.id == 1).first()
+        self.assertTrue(quotation)
+        self.assertEqual(quotation.title, '○○株式会社への見積書')
+
+        print('---Quotation一件読み込み失敗---')
+        quotations = Quotation.query.filter(Quotation.id == 9999).all()
+        self.assertFalse(quotations)
+        self.assertEqual(len(quotations), 0)
+
+    def test_update_quotation(self):
+        print('---Quotation一件更新---')
+        quotation = Quotation.query.filter(Quotation.id == 2).first()
+        quotation.title = '××株式会社への見積書'
+        db.session.commit()
+        quotation = Quotation.query.filter(Quotation.id == 2).first()
+        self.assertEqual(quotation.title, "××株式会社への見積書")
+
+    def test_create_quotation(self):
+        print('---Quotation新規作成---')
+        quotations = [
+            Quotation(customerId=1, customerName='○○建設', applyNumber=1000004, applyDate=datetime.now(), expiry=datetime.now(),
+                      title='○○建設への見積書', memo='これは見積書のメモです', remarks='これは見積書の備考です', isTaxExp=True, isDelete=False),
+            Quotation(customerId=1, customerName='○○商店', applyNumber=1000005, applyDate=datetime.now(), expiry=datetime.now(),
+                      title='○○商店への見積書', memo='これは見積書のメモです', remarks='これは見積書の備考です', isTaxExp=True, isDelete=False),
+        ]
+        db.session.add_all(quotations)
+        db.session.commit()
+        self.assertGreaterEqual(len(Quotation.query.all()), 2)
+
+    def test_delete_quotation(self):
+        print('---Quotation一件削除---')
+        quotation = Quotation(customerId=1, customerName='テスト会社', applyNumber=1000006, applyDate=datetime.now(), expiry=datetime.now(),
+                              title='○○株式会社への見積書', memo='これは見積書のメモです', remarks='これは見積書の備考です', isTaxExp=True, isDelete=False)
+        db.session.add(quotation)
+        db.session.commit()
+        newId = quotation.id
+        quotation = Quotation.query.filter(Quotation.id == newId).delete()
+        db.session.commit()
+
+        quotation = Quotation.query.filter(Quotation.id == newId).all()
+        self.assertEqual(len(quotation), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_quotation_item.py
+++ b/app/test_quotation_item.py
@@ -1,0 +1,90 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_quotation_items(self):
+        print('---Quotation_Item全件読み込み---')
+        quotationItems = Quotation_Item.query.all()
+        quotationItemCount = len(quotationItems)
+        self.assertTrue(quotationItemCount)
+        print('---Quotation_Item→Customer全件取得---')
+        customerCount = 0
+        for quotationItem in quotationItems:
+            if quotationItem.quotation.customer is not None:
+                customerCount += 1
+        self.assertGreaterEqual(customerCount, 1)
+
+    def test_get_quotation_item_byId(self):
+        print('---Quotation_Item全件取得→Dict---')
+        quotationItems = Quotation_Item.query.all()
+        sch = Quotation_ItemSchema(many=True).dump(quotationItems)
+        self.assertEqual(sch[0]['price'], 100)
+
+    def test_get_quotation_item_byId(self):
+        print('---Quotation_Item一件読み込み---')
+        quotationItem = Quotation_Item.query.filter(
+            Quotation_Item.id == 1).first()
+        self.assertTrue(quotationItem)
+        self.assertEqual(quotationItem.count, 5)
+
+        print('---Quotation_Item一件読み込み失敗---')
+        quotationItems = Quotation_Item.query.filter(
+            Quotation_Item.id == 9999).all()
+        self.assertFalse(quotationItems)
+        self.assertEqual(len(quotationItems), 0)
+
+    def test_update_quotation_item(self):
+        print('---Quotation_Item一件更新---')
+        quotationItem = Quotation_Item.query.filter(
+            Quotation_Item.id == 2).first()
+        quotationItem.count = 20
+        db.session.commit()
+        quotationItem = Quotation_Item.query.filter(
+            Quotation_Item.id == 2).first()
+        self.assertEqual(quotationItem.count, 20)
+
+    def test_create_quotation_item(self):
+        print('---Quotation_Item新規作成---')
+        quotationItems = [
+            Quotation_Item(quotationId=3, itemId=2, itemName='鉛筆',
+                           price=100, cost=20, count=20, unit='本'),
+            Quotation_Item(quotationId=3, itemId=3, itemName='ラジオ',
+                           price=200, cost=100, count=10, unit='台'),
+        ]
+        db.session.add_all(quotationItems)
+        db.session.commit()
+        self.assertGreaterEqual(len(Quotation_Item.query.all()), 2)
+
+    def test_delete_quotation_item(self):
+        print('---Quotation_Item一件削除---')
+        quotationItem = Quotation_Item(
+            quotationId=1, itemId=1, itemName='りんご', price=999, cost=100, count=10, unit='個')
+        db.session.add(quotationItem)
+        db.session.commit()
+        newId = quotationItem.id
+        quotationItem = Quotation_Item.query.filter(
+            Quotation_Item.id == newId).delete()
+        db.session.commit()
+
+        quotationItem = Quotation_Item.query.filter(
+            Quotation_Item.id == newId).all()
+        self.assertEqual(len(quotationItem), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_setting.py
+++ b/app/test_setting.py
@@ -1,0 +1,73 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    # Settingは一件だけかと思うので一応コメントアウト
+    # def test_get_settings(self):
+    #     print('---Setting全件読み込み---')
+    #     settings = Setting.query.all()
+    #     settingCount = len(settings)
+    #     self.assertTrue(settingCount)
+
+    def test_get_setting_dict(self):
+        print('---Setting一件読込→Dict---')
+        setting = Setting.query.filter(Setting.id == 1).first()
+        sch = SettingSchema().dump(setting)
+        self.assertEqual(sch['companyName'], '自社株式会社')
+
+    def test_get_setting_byId(self):
+        print('---Setting一件読み込み---')
+        setting = Setting.query.filter(Setting.id == 1).first()
+        self.assertTrue(setting)
+        self.assertEqual(setting.companyName, '自社株式会社')
+
+        print('---Setting一件読み込み失敗---')
+        settings = Setting.query.filter(Setting.id == 9999).all()
+        self.assertFalse(settings)
+        self.assertEqual(len(settings), 0)
+
+    def test_update_setting(self):
+        print('---Setting一件更新---')
+        setting = Setting.query.filter(Setting.id == 1).first()
+        setting.companyName = 'テスト入力株式会社'
+        db.session.commit()
+        setting = Setting.query.filter(Setting.id == 1).first()
+        self.assertEqual(setting.companyName, "テスト入力株式会社")
+
+    # Settingは一件だけかと思うので一応コメントアウト
+    # def test_create_setting(self):
+    #     print('---Setting新規作成---')
+    #     settings = [
+    #         Setting(settingName='式'),
+    #         Setting(settingName='枚'),
+    #     ]
+    #     db.session.add_all(settings)
+    #     db.session.commit()
+    #     self.assertGreaterEqual(len(Setting.query.all()), 2)
+
+    # def test_delete_setting(self):
+    #     print('---Setting一件削除---')
+    #     setting = Setting.query.filter(Setting.id == 1).delete()
+    #     db.session.commit()
+
+    #     setting = Setting.query.filter(Setting.id == 1).all()
+    #     self.assertGreaterEqual(len(setting), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_unit.py
+++ b/app/test_unit.py
@@ -1,0 +1,75 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_units(self):
+        print('---Unit全件読み込み---')
+        units = Unit.query.all()
+        unitCount = len(units)
+        self.assertTrue(unitCount)
+
+    def test_get_units_dict(self):
+        print('---Unit全件読込→Dict---')
+        units = Unit.query.all()
+        sch = UnitSchema(many=True).dump(units)
+        self.assertEqual(sch[0]['unitName'], '個')
+
+    def test_get_unit_byId(self):
+        print('---Unit一件読み込み---')
+        unit = Unit.query.filter(Unit.id == 1).first()
+        self.assertTrue(unit)
+        self.assertEqual(unit.unitName, '個')
+
+        print('---Unit一件読み込み失敗---')
+        units = Unit.query.filter(Unit.id == 9999).all()
+        self.assertFalse(units)
+        self.assertEqual(len(units), 0)
+
+    def test_update_unit(self):
+        print('---Unit一件更新---')
+        unit = Unit.query.filter(Unit.id == 2).first()
+        unit.unitName = '丁'
+        db.session.commit()
+        unit = Unit.query.filter(Unit.id == 2).first()
+        self.assertEqual(unit.unitName, "丁")
+
+    def test_create_unit(self):
+        print('---Unit新規作成---')
+        units = [
+            Unit(unitName='式'),
+            Unit(unitName='枚'),
+        ]
+        db.session.add_all(units)
+        db.session.commit()
+        self.assertGreaterEqual(len(Unit.query.all()), 2)
+
+    def test_delete_unit(self):
+        print('---Unit一件削除---')
+        unit = Unit(unitName='点')
+        db.session.add(unit)
+        db.session.commit()
+        newId = unit.id
+        unit = Unit.query.filter(Unit.id == newId).delete()
+        db.session.commit()
+
+        unit = Unit.query.filter(Unit.id == newId).all()
+        self.assertEqual(len(unit), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_user.py
+++ b/app/test_user.py
@@ -1,0 +1,78 @@
+from app import db, app
+from models import *
+import unittest
+from seeder import seeder
+
+
+class BasicTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # print('-----setUp-----')
+        pass
+
+    # テスト後にシーダーを流しなおす
+    @classmethod
+    def tearDownClass(cls):
+        print("---tearDown---")
+        seeder()
+
+    def test_get_users(self):
+        print('---User全件読み込み---')
+        users = User.query.all()
+        userCount = len(users)
+        self.assertTrue(userCount)
+
+    def test_get_users_dict(self):
+        print('---User全件読み込み→Dict---')
+        users = User.query.all()
+        sch = UserSchema(many=True).dump(users)
+        self.assertEqual(sch[0]['name'], 'tanaka_taro')
+
+    def test_get_user_byId(self):
+        print('---User一件読み込み---')
+        user = User.query.filter(User.id == 1).first()
+        self.assertTrue(user)
+        self.assertEqual(user.name, 'tanaka_taro')
+
+        print('---User一件読み込み失敗---')
+        users = User.query.filter(User.id == 9999).all()
+        self.assertFalse(users)
+        self.assertEqual(len(users), 0)
+
+    def test_update_user(self):
+        print('---User一件更新---')
+        user = User.query.filter(User.id == 2).first()
+        user.name = 'hogehoge'
+        db.session.commit()
+        user = User.query.filter(User.id == 2).first()
+        self.assertEqual(user.name, "hogehoge")
+
+    def test_create_user(self):
+        print('---User新規作成---')
+        users = [
+            User(name='kojima_siro', password='password',
+                 group='operator', role='admin'),
+            User(name='yamada_goro', password='password',
+                 group='guest', role='admin'),
+        ]
+        db.session.add_all(users)
+        db.session.commit()
+        self.assertGreaterEqual(len(User.query.all()), 2)
+
+    def test_delete_user(self):
+        print('---User一件削除---')
+        user = User(name='hogehoge', password='password',
+                    group='guest', role='admin')
+        db.session.add(user)
+        db.session.commit()
+        newId = user.id
+        user = User.query.filter(User.id == newId).delete()
+        db.session.commit()
+
+        user = User.query.filter(User.id == newId).all()
+        self.assertEqual(len(user), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- テストファイルのファイル名変更
- カラム変更を更新してなかったので更新

change file数が多くて見ずらいので２回に分ける。
あとで追加されたモデルのテストもプルリク出す。