### PR TITLE
モーダルの選択肢を出現時にEnterで選択できるように。Itemページのみ適用。

### DIFF
--- a/app/static/component/select-modal.js
+++ b/app/static/component/select-modal.js
@@ -9,7 +9,7 @@ Vue.component('select-modal', {
             <b-row>
                 <b-col></b-col>
                 <router-link to="?page=index">
-                    <b-button variant="danger" @click="isResult=true;select();">はい</b-button>
+                    <b-button variant="danger" @click="isResult=true;select();" id="modal-confirm">はい</b-button>
                 </router-link>
                 <b-col></b-col>
                 <b-button variant="info" @click="isResult=false;select();">いいえ</b-button>

--- a/app/static/item.html
+++ b/app/static/item.html
@@ -318,6 +318,10 @@
                     this.item = item;
                     console.log(this.item);
                     this.$bvModal.show(modalName);
+                    // モーダル内の要素を取得するには処理を遅らせる
+                    window.setTimeout(function () {
+                        document.getElementById('modal-confirm').focus();
+                    }, 1);
                 },
                 deleteModalProcess(result) {
                     this.$bvModal.hide('deleteModal');


### PR DESCRIPTION
新規作成・更新時の「適用」を押下後、項目の削除ボタン押下後に出現するモーダルを出現時にEnterで「はい」を選択できるようにした。
モーダル内の要素を選択する場合、どうやら非同期で処理を遅らせる必要があるようだ。
setTimeoutを使っているのだが、カッコ悪いので他の書き方があれば教えて欲しい。

Issue：モーダル内をJSでいじれない #67
はこれが原因だったようだ。原因がわかったのでIssueはCloseしておく。