### PR TITLE
ENTER移動ではなく普通にタブ移動の方式見本。

### DIFF
--- a/app/static/component/select-modal.js
+++ b/app/static/component/select-modal.js
@@ -9,7 +9,7 @@ Vue.component('select-modal', {
             <b-row>
                 <b-col></b-col>
                 <router-link to="?page=index">
-                    <b-button variant="danger" @click="isResult=true;select();">はい</b-button>
+                    <b-button variant="danger" @click="isResult=true;select();" id="modal-confirm">はい</b-button>
                 </router-link>
                 <b-col></b-col>
                 <b-button variant="info" @click="isResult=false;select();">いいえ</b-button>

--- a/app/static/component/select-modal.js
+++ b/app/static/component/select-modal.js
@@ -2,14 +2,14 @@ Vue.component('select-modal', {
     template:
         `
     <div>
-        <b-modal :id="modalName" hide-footer>     
+        <b-modal :id="modalName" @shown="focusOK" hide-footer>     
             <div class="d-block text-center">
                 <h3>{{ modalMessage }}</h3>
             </div>
             <b-row>
                 <b-col></b-col>
                 <router-link to="?page=index">
-                    <b-button variant="danger" @click="isResult=true;select();" id="modal-confirm">はい</b-button>
+                    <b-button ref="focusThis" variant="danger" @click="isResult=true;select();" id="modal-confirm">はい</b-button>
                 </router-link>
                 <b-col></b-col>
                 <b-button variant="info" @click="isResult=false;select();">いいえ</b-button>
@@ -28,6 +28,9 @@ Vue.component('select-modal', {
     methods: {
         select() {
             this.$emit("selected", isResult);
+        },
+        focusOK(){
+            this.$refs.focusThis.focus();
         }
     }
 })

--- a/app/static/item.html
+++ b/app/static/item.html
@@ -317,11 +317,12 @@
                 modalShow: function (item, modalName) {
                     this.item = item;
                     console.log(this.item);
+                    //document.getElementById('modal-confirm').focus();
                     this.$bvModal.show(modalName);
                     // モーダル内の要素を取得するには処理を遅らせる
-                    window.setTimeout(function () {
-                        document.getElementById('modal-confirm').focus();
-                    }, 1);
+                    //window.setTimeout(function () {
+                    //    document.getElementById('modal-confirm').focus();
+                    //}, 1);
                 },
                 deleteModalProcess(result) {
                     this.$bvModal.hide('deleteModal');

--- a/app/static/item.html
+++ b/app/static/item.html
@@ -117,62 +117,63 @@
                         <b-button @click="getItems();">＜</b-button>
                     </router-link>
                     <b-card border-variant="white" class="mb-3 text-center" header="商品入力" header-border-variant="light">
+                        
                         <b-row>
-                            <b-col>
-
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="商品名"
-                                    label-for="itemName">
-                                    <b-form-input v-model="item.itemName" id="itemName" size="sm"
-                                        @keydown.enter="enterInput" tabindex="0">
-                                    </b-form-input>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="商品名" label-for="itemName">
+                                    <b-form-input v-model="item.itemName" id="itemName" size="sm"></b-form-input>
+                                </b-form-group>                                
+                            </b-col>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="商品コード" label-for="itemCode">
+                                    <b-form-input v-model="item.itemCode" id="itemCode" size="sm"></b-form-input>
                                 </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="カテゴリ"
-                                    label-for="category">
-                                    <b-form-select v-model="item.category" :options="categories" size="sm"
-                                        @keydown.enter="enterInput" tabindex="2">
-                                    </b-form-select>
+                            </b-col>
+                        </b-row>
+                        <b-row>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="カテゴリ" label-for="category">
+                                    <b-form-select v-model="item.category" :options="categories" size="sm"></b-form-select>
                                 </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単位"
-                                    label-for="unit">
-                                    <b-form-select v-model="item.unit" :options="units" size="sm"
-                                        @keydown.enter="enterInput" tabindex="4"></b-form-select>
+                            </b-col>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メーカー">
+                                    <b-form-select v-model="item.maker" :options="makers" size="sm"></b-form-select>
+                                </b-form-group>                                    
+                            </b-col>
+                        </b-row>
+                        <b-row>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単位" label-for="unit">
+                                    <b-form-select v-model="item.unit" :options="units" size="sm"></b-form-select>
+                                </b-form-group>                                    
+                            </b-col>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="型式" label-for="model">
+                                    <b-form-input v-model="item.model" id="model" size="sm" ></b-form-input>
                                 </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単価"
-                                    label-for="basePrice">
-                                    <b-form-input v-model="item.basePrice" id="basePrice" size="sm"
-                                        @keydown.enter="enterInput" tabindex="6" type="number">
-                                    </b-form-input>
-                                </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単価原価"
-                                    label-for="baseCost">
-                                    <b-form-input v-model="item.baseCost" id="baseCost" size="sm"
-                                        @keydown.enter="enterInput" tabindex="7" type="number">
+                            </b-col>
+                        </b-row>
+                        <b-row>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単価" label-for="basePrice">
+                                    <b-form-input v-model="item.basePrice" id="basePrice" size="sm" type="number"></b-form-input>
                                     </b-form-input>
                                 </b-form-group>
                             </b-col>
-                            <b-col>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="商品コード"
-                                    label-for="itemCode">
-                                    <b-form-input v-model="item.itemCode" id="itemCode" size="sm"
-                                        @keydown.enter="enterInput" tabindex="1">
-                                    </b-form-input>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単価原価" label-for="baseCost">
+                                    <b-form-input v-model="item.baseCost" id="baseCost" size="sm" type="number"></b-form-input>
                                 </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メーカー"
-                                    label-for="maker">
-                                    <b-form-select v-model="item.maker" :options="makers" size="sm"
-                                        @keydown.enter="enterInput" tabindex="3"></b-form-select>
+                            </b-col>
+                        </b-row>
+                        <b-row>
+                            <b-col sm>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ" label-for="メモ">
+                                    <b-form-textarea v-model="item.memo" size="sm" rows="4"></b-form-textarea>
                                 </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="型式"
-                                    label-for="model">
-                                    <b-form-input v-model="item.model" id="model" size="sm" @keydown.enter="enterInput"
-                                        tabindex="5">
-                                    </b-form-input>
-                                </b-form-group>
-                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                    label-for="メモ">
-                                    <b-form-textarea v-model="item.memo" size="sm" tabindex="8" rows="4">
-                                    </b-form-textarea>
-                                </b-form-group>
+                            </b-col>
+                            <b-col sm>
                             </b-col>
                         </b-row>
                     </b-card>
@@ -183,7 +184,6 @@
             </b-row>
 
         </div>
-
         <!-- 空行 -->
         <b-row class="mb-5"></b-row>
         <b-row class="mb-5"></b-row>
@@ -317,12 +317,7 @@
                 modalShow: function (item, modalName) {
                     this.item = item;
                     console.log(this.item);
-                    //document.getElementById('modal-confirm').focus();
                     this.$bvModal.show(modalName);
-                    // モーダル内の要素を取得するには処理を遅らせる
-                    //window.setTimeout(function () {
-                    //    document.getElementById('modal-confirm').focus();
-                    //}, 1);
                 },
                 deleteModalProcess(result) {
                     this.$bvModal.hide('deleteModal');
@@ -335,11 +330,6 @@
                     if (result === true) {
                         this.bulkUpsert(this.item);
                     }
-                },
-                enterInput(event) {
-                    const tabindex = Number(event.target.getAttribute('tabindex'));
-                    const nextTabindex = tabindex + 1;
-                    document.querySelector(`[tabindex="${nextTabindex}"]`).focus();
                 },
             },
             mounted: function () {
@@ -357,7 +347,6 @@
                 },
             }
         })
-
 
     </script>
 

--- a/app/static/item.html
+++ b/app/static/item.html
@@ -318,6 +318,10 @@
                     this.item = item;
                     console.log(this.item);
                     this.$bvModal.show(modalName);
+                    // モーダル内の要素を取得するには処理を遅らせる
+                    window.setTimeout(function () {
+                        document.getElementById('modal-confirm').focus();
+                    }, 1);
                 },
                 deleteModalProcess(result) {
                     this.$bvModal.hide('deleteModal');


### PR DESCRIPTION
・タブで移動した場合のモデルです。
・b-rowのなかでb-colを並べる。
・タブインデックスを管理しなくてよい
・こうすることでレスポンス対応が楽にもなる。