### PR TITLE
得意先・請求・見積ページ。削除ボタンを詳細画面に変更。

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -51,7 +51,6 @@
                       {  key: 'address', label: '住所' },
                       {  key: 'telNumber', label: '電話番号', tdClass:'td-telNumber' },
                       {  key: 'memo', label: 'メモ' },
-                      {  key: 'delete', label: '' },
                     ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">
@@ -59,11 +58,6 @@
                                                 class="fas fa-edit"></i>
                                         </b-button>
                                     </router-link>
-                                </template>
-                                <template v-slot:cell(delete)="data">
-                                    <b-button variant="danger" @click="modalShow(data.item,'deleteModal');">
-                                        <i class="fas fa-trash-alt"></i>
-                                    </b-button>
                                 </template>
                             </b-table>
 
@@ -74,9 +68,6 @@
                     </b-col>
                     <b-col></b-col>
                 </b-row>
-                <!-- 削除モーダル -->
-                <select-modal modal-name='deleteModal' modal-message='削除しますか？'
-                    @selected="deleteModalProcess($event);" />
             </div>
 
             <!-- 新規作成・詳細(更新)ページ -->
@@ -236,17 +227,27 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" class="mr-3" @click="modalShow(customer,'upsertModal');"
-                            id="showUpsertModal">適用
-                        </b-button>
+                        <b-button pill variant="info" @click="modalShow(customer,'upsertModal');" id="showUpsertModal">
+                            適用</b-button>
                         <b-button pill size="lg" variant="info" @click="pdfOut"><i class="fas fa-print"></i>
+                        </b-button>
+                        <b-button pill size="lg" variant="danger" @click="modalShow(customer,'deleteModal');">
+                            <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>
                 </b-row>
             </b-card>
 
             <!-- 保存モーダル -->
-            <select-modal modal-name='upsertModal' modal-message='保存しますか？' @selected="upsertModalProcess($event);" />
+            <div>
+                <select-modal modal-name='upsertModal' modal-message='保存しますか？'
+                    @selected="upsertModalProcess($event);" />
+            </div>
+            <!-- 削除モーダル -->
+            <div>
+                <select-modal modal-name='deleteModal' modal-message='削除しますか？'
+                    @selected="deleteModalProcess($event);" />
+            </div>
 
         </div>
 

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -71,7 +71,6 @@
                           {  key: 'deadLine', label: '支払期限' },
                           {  key: 'title', label: '件名' },
                           {  key: 'memo', label: 'メモ' },
-                          {  key: 'delete', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">
@@ -86,11 +85,6 @@
                                 <template v-slot:cell(deadLine)="data">
                                     <p class="text-left pl-2" id="deadLine">{{formatDate(data.item.deadLine)}}</p>
                                 </template>
-                                <template v-slot:cell(delete)="data">
-                                    <b-button variant="danger" @click="modalShow(data.item,'deleteModal');">
-                                        <i class="fas fa-trash-alt"></i>
-                                    </b-button>
-                                </template>
                             </b-table>
 
                             <b-pagination v-model="invoicesCurrentPage" :total-rows="invoicesCurrentPageRows"
@@ -100,11 +94,6 @@
                     </b-col>
                     <b-col></b-col>
                 </b-row>
-
-                <!-- 削除モーダル -->
-                <select-modal modal-name='deleteModal' modal-message='削除しますか？'
-                    @selected="deleteModalProcess($event);" />
-
             </div>
 
             <!-- 新規作成・詳細(更新)ページ -->
@@ -374,17 +363,27 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" class="mr-3" @click="modalShow(invoice,'upsertModal');"
-                            id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(invoice,'upsertModal');" id="showUpsertModal">適用
                         </b-button>
                         <b-button pill size="lg" variant="info" @click="pdfout" id="pdfout"><i class="fas fa-print"></i>
+                        </b-button>
+                        <b-button pill size="lg" variant="danger" @click="modalShow(invoice,'deleteModal');">
+                            <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>
                 </b-row>
             </b-card>
 
             <!-- 保存モーダル -->
-            <select-modal modal-name='upsertModal' modal-message='保存しますか？' @selected="upsertModalProcess($event);" />
+            <div>
+                <select-modal modal-name='upsertModal' modal-message='保存しますか？'
+                    @selected="upsertModalProcess($event);" />
+            </div>
+            <!-- 削除モーダル -->
+            <div>
+                <select-modal modal-name='deleteModal' modal-message='削除しますか？'
+                    @selected="deleteModalProcess($event);" />
+            </div>
 
         </div>
         <script src="static/component/def-pdf.js"></script>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -70,7 +70,6 @@
                           {  key: 'expiry', label: '見積有効期限' },
                           {  key: 'title', label: '件名' },
                           {  key: 'memo', label: 'メモ' },
-                          {  key: 'delete', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">
@@ -85,11 +84,6 @@
                                 <template v-slot:cell(expiry)="data">
                                     <p class="text-left pl-2" id="expiry">{{formatDate(data.item.expiry)}}</p>
                                 </template>
-                                <template v-slot:cell(delete)="data">
-                                    <b-button variant="danger" @click="modalShow(data.item,'deleteModal');">
-                                        <i class="fas fa-trash-alt"></i>
-                                    </b-button>
-                                </template>
                             </b-table>
 
                             <b-pagination v-model="quotationsCurrentPage" :total-rows="quotationsCurrentPageRows"
@@ -99,11 +93,6 @@
                     </b-col>
                     <b-col></b-col>
                 </b-row>
-
-                <!-- 削除モーダル -->
-                <select-modal modal-name='deleteModal' modal-message='削除しますか？'
-                    @selected="deleteModalProcess($event);" />
-
             </div>
 
             <!-- 新規作成・詳細(更新)ページ -->
@@ -373,17 +362,28 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" class="mr-3" @click="modalShow(quotation,'upsertModal');"
-                            id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(quotation,'upsertModal');" id="showUpsertModal">
+                            適用
                         </b-button>
                         <b-button pill size="lg" variant="info" @click="pdfout" id="pdfout"><i class="fas fa-print"></i>
+                        </b-button>
+                        <b-button pill size="lg" variant="danger" @click="modalShow(quotation,'deleteModal');">
+                            <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>
                 </b-row>
             </b-card>
 
             <!-- 保存モーダル -->
-            <select-modal modal-name='upsertModal' modal-message='保存しますか？' @selected="upsertModalProcess($event);" />
+            <div>
+                <select-modal modal-name='upsertModal' modal-message='保存しますか？'
+                    @selected="upsertModalProcess($event);" />
+            </div>
+            <!-- 削除モーダル -->
+            <div>
+                <select-modal modal-name='deleteModal' modal-message='削除しますか？'
+                    @selected="deleteModalProcess($event);" />
+            </div>
 
         </div>
 


### PR DESCRIPTION
フッターにボタンを配置

関連Issue：得意先・請求書・見積書ページの一覧には削除ボタンを設けず、詳細画面に設ける。 #388