### PR TITLE
請求・見積書の得意先選択モーダル。一覧表示項目削除

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -159,11 +159,6 @@
                                                 label="Table Options" :fields="[
                                   {  key: 'id', label: 'No.' },
                                   {  key: 'customerName', label: '顧客名' },
-                                  {  key: 'postNum',   label: '郵便番号' },
-                                  {  key: 'address',  label: '住所' },
-                                  {  key: 'telNumber',  label: '電話番号' },
-                                  {  key: 'representative', label: '代表者名' },
-                                  {  key: 'memo', label: 'メモ' },
                                 ]"></b-table>
 
                                             <b-pagination v-model="customersCurrentPage"

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -159,11 +159,6 @@
                                                 label="Table Options" :fields="[
                                   {  key: 'id', label: 'No.' },
                                   {  key: 'customerName', label: '顧客名' },
-                                  {  key: 'postNum',   label: '郵便番号' },
-                                  {  key: 'address',  label: '住所' },
-                                  {  key: 'telNumber',  label: '電話番号' },
-                                  {  key: 'representative', label: '代表者名' },
-                                  {  key: 'memo', label: 'メモ' },
                                 ]"></b-table>
 
                                             <b-pagination v-model="customersCurrentPage"


### PR DESCRIPTION
請求・見積書の得意先選択モーダル。一覧のNo.と得意先名以外の項目を削除した。

関連Issue：請求・見積ページの顧客選択モーダル。表示はNoと顧客名のみに。 #416