### PR TITLE
得意先カナページネーション(フィルター)原案完成

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -43,7 +43,7 @@ class Customer(db.Model):
         db.String, nullable=False, default='corporation')
     isHide = db.Column(db.Boolean, nullable=False, default=False)
     isFavorite = db.Column(db.Boolean, nullable=False,
-                           server_default=db.text('0'))
+                           default=False, server_default=db.text('0'))
     memo = db.Column(db.String)
     createdAt = db.Column(db.DateTime, nullable=False, default=datetime.now)
     updatedAt = db.Column(db.DateTime, nullable=False,

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -44,7 +44,7 @@
                             <b-form-checkbox class="text-right" v-model="isShowFavorite">お気に入り</b-form-checkbox>
                             <b-form-checkbox class="text-right" v-model="isShowAll">全て表示</b-form-checkbox>
                             <b-table responsive hover small id="customertable" sort-by="ID" small label="Table Options"
-                                :items=customersIndicateIndex :per-page="perPage" :current-page="currentPage" :fields="[
+                                :items=customersIndicateIndex :fields="[
                       {  key: 'update', label: '' },
                       {  key: 'id', label: 'No.' },
                       {  key: 'customerName', label: '得意先名' },
@@ -62,8 +62,12 @@
                                 </template>
                             </b-table>
 
-                            <b-pagination v-model="currentPage" :total-rows="currentPageRows" :per-page="perPage"
-                                aria-controls="customertable"></b-pagination>
+                            <template>
+                                <div class="overflow-auto">
+                                    <b-pagination-nav :link-gen="linkGen" :page-gen="pageGen" @change="kanaSelect"
+                                        :number-of-pages="syllabaryList.length"></b-pagination-nav>
+                                </div>
+                            </template>
 
                         </b-card>
                     </b-col>
@@ -323,6 +327,10 @@
                     isShowFavorite: false,
                     perPage: 20,                //ページネーション
                     currentPage: 1,             //ページネーション
+                    syllabaryList: ['#　', '#ア', '#イ', '#ウ', '#エ', '#オ', '#カ', '#キ', '#ク', '#ケ', '#コ', '#サ', '#シ', '#ス', '#セ', '#ソ',
+                        '#タ', '#チ', '#ツ', '#テ', '#ト', '#ナ', '#ニ', '#ヌ', '#ネ', '#ノ', '#ハ', '#ヒ', '#フ', '#へ', '#ホ', '#マ', '#ミ', '#ム', '#メ', '#モ',
+                        '#ヤ', '#ユ', '#ヨ', '#ラ', '#リ', '#ル', '#レ', '#ロ', '#ワ', '#ヲ', '#ン',],
+                    syllabarySelect: '',
                 },
                 methods: {
                     // ---Customers---
@@ -444,6 +452,19 @@
                     formatDate(date) {
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
+                    // リンクへの挿入
+                    linkGen(pageNum) {
+                        return this.syllabaryList[pageNum - 1];
+                    },
+                    // ボタンの文字
+                    pageGen(pageNum) {
+                        return this.syllabaryList[pageNum - 1].slice(1);
+                    },
+                    kanaSelect(page) {
+                        let word = this.syllabaryList[page - 1].slice(1);
+                        if (word === "　") word = "";
+                        this.syllabarySelect = word;
+                    },
                 },
                 mounted: function () {
                     this.customer = JSON.parse(localStorage.getItem('customer'));
@@ -465,11 +486,8 @@
                             customers = customers.filter(customer => customer.isHide === false);
                         if (this.isShowFavorite === true)
                             customers = customers.filter(customer => customer.isFavorite === true);
+                        customers = customers.filter(customer => !customer.customerKana.indexOf(this.syllabarySelect));
                         return customers;
-                    },
-                    // ページネーション
-                    currentPageRows() {
-                        return this.customers.length;
                     },
                     // バリデーション
                     customerKanaValidate() {


### PR DESCRIPTION
得意先カナページネーション（フィルター）機能のイメージがぼんやりしているのでとりあえず原案を作成。
ついでにisFavorite未入力時のInsertバグ修正。

- 得意先モーダルへの反映は未実装
- 英数字のフィルタリングは未実装

すり合わせが完了でき次第上記２項目も完了する。