### PR TITLE
得意先一覧。住所項目を住所１と住所２を合わせたものにした。

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -51,7 +51,7 @@
                       {  key: 'id', label: 'No.', sortable: true },
                       {  key: 'customerName', label: '得意先名', sortable: true },
                       {  key: 'postNumber', label: '郵便番号', tdClass:'td-postNumber' },
-                      {  key: 'address', label: '住所' },
+                      {  key: 'addressCombine', label: '住所' },
                       {  key: 'telNumber', label: '電話番号', tdClass:'td-telNumber' },
                       {  key: 'memo', label: 'メモ' },
                     ]" :tbody-tr-class="rowClass">
@@ -61,6 +61,9 @@
                                                 class="fas fa-edit"></i>
                                         </b-button>
                                     </router-link>
+                                </template>
+                                <template v-slot:cell(addressCombine)="data">
+                                    {{data.item.address + data.item.addressSub}}
                                 </template>
                             </b-table>
 


### PR DESCRIPTION
関連Issue：得意先一覧画面。住所１と住所２は合わせて表示する #487