### PR TITLE
デフォルトのソートを得意先カナに。住所表示バグ修正。

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -63,7 +63,7 @@
                                     </router-link>
                                 </template>
                                 <template v-slot:cell(addressCombine)="data">
-                                    {{data.item.address + data.item.addressSub}}
+                                    {{combineAddress(data.item.address,data.item.addressSub)}}
                                 </template>
                             </b-table>
 
@@ -322,7 +322,7 @@
             var app = new Vue({
                 el: '#app',
                 data: {
-                    sortByCustomers: 'customerName',
+                    sortByCustomers: 'customerKana',
                     customers: [],               //全件customer
                     customer: [],                //選択中のcustomer
                     isShowAll: false,            // trueの時、全表示
@@ -453,6 +453,11 @@
                     },
                     formatDate(date) {
                         if (!!date) return moment(date).format("YYYY/MM/DD");
+                    },
+                    combineAddress(address1, address2) {
+                        if (!address1) address1 = "";
+                        if (!address2) address2 = "";
+                        return String(address1) + String(address2);
                     },
                     // リンクへの挿入
                     linkGen(pageNum) {


### PR DESCRIPTION
- 得意先ページ一覧。得意先カナでソート
- 住所がnullだった際に0と表示されるバグ修正。