### PR TITLE
得意先一覧。検索機能の追加。得意先カナに対応。

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -41,9 +41,20 @@
                     <b-col cols="11">
                         <b-card border-variant="white" class="mb-3 text-center" header="得意先一覧"
                             header-border-variant="light">
-                            <b-row align-h="end">
-                                <b-form-checkbox class="mr-3" v-model="isShowFavorite">お気に入り</b-form-checkbox>
-                                <b-form-checkbox class="mr-3" v-model="isShowAll">全て表示</b-form-checkbox>
+                            <b-row>
+                                <b-col>
+                                    <b-form-group sm label-cols="2" label-size="sm" label-align="center" label="検索"
+                                        label-for="searchCustomerWord">
+                                        <b-form-input v-model="searchCustomerWord" id="searchCustomerWord" size="sm">
+                                        </b-form-input>
+                                    </b-form-group>
+                                </b-col>
+                                <b-col>
+                                    <b-row align-h="end">
+                                        <b-form-checkbox class="mr-3" v-model="isShowFavorite">お気に入り</b-form-checkbox>
+                                        <b-form-checkbox class="mr-3" v-model="isShowAll">全て表示</b-form-checkbox>
+                                    </b-row>
+                                </b-col>
                             </b-row>
                             <b-table responsive hover small id="customertable" sort-by="ID" small label="Table Options"
                                 :items=customersIndicateIndex :sort-by.sync="sortByCustomers" :fields="[
@@ -66,13 +77,6 @@
                                     {{data.item.address + data.item.addressSub}}
                                 </template>
                             </b-table>
-
-                            <template>
-                                <div class="overflow-auto">
-                                    <b-pagination-nav :link-gen="linkGen" :page-gen="pageGen" @change="kanaSelect"
-                                        :number-of-pages="syllabaryList.length"></b-pagination-nav>
-                                </div>
-                            </template>
 
                         </b-card>
                     </b-col>
@@ -323,16 +327,13 @@
                 el: '#app',
                 data: {
                     sortByCustomers: 'customerName',
+                    searchCustomerWord: '',
                     customers: [],               //全件customer
                     customer: [],                //選択中のcustomer
                     isShowAll: false,            // trueの時、全表示
                     isShowFavorite: false,
                     perPage: 20,                //ページネーション
                     currentPage: 1,             //ページネーション
-                    syllabaryList: ['#　', '#ア', '#イ', '#ウ', '#エ', '#オ', '#カ', '#キ', '#ク', '#ケ', '#コ', '#サ', '#シ', '#ス', '#セ', '#ソ',
-                        '#タ', '#チ', '#ツ', '#テ', '#ト', '#ナ', '#ニ', '#ヌ', '#ネ', '#ノ', '#ハ', '#ヒ', '#フ', '#へ', '#ホ', '#マ', '#ミ', '#ム', '#メ', '#モ',
-                        '#ヤ', '#ユ', '#ヨ', '#ラ', '#リ', '#ル', '#レ', '#ロ', '#ワ', '#ヲ', '#ン',],
-                    syllabarySelect: '',
                 },
                 methods: {
                     // ---Customers---
@@ -454,19 +455,6 @@
                     formatDate(date) {
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
-                    // リンクへの挿入
-                    linkGen(pageNum) {
-                        return this.syllabaryList[pageNum - 1];
-                    },
-                    // ボタンの文字
-                    pageGen(pageNum) {
-                        return this.syllabaryList[pageNum - 1].slice(1);
-                    },
-                    kanaSelect(page) {
-                        let word = this.syllabaryList[page - 1].slice(1);
-                        if (word === "　") word = "";
-                        this.syllabarySelect = word;
-                    },
                 },
                 mounted: function () {
                     this.customer = JSON.parse(localStorage.getItem('customer'));
@@ -488,7 +476,9 @@
                             customers = customers.filter(customer => customer.isHide === false);
                         if (this.isShowFavorite === true)
                             customers = customers.filter(customer => customer.isFavorite === true);
-                        customers = customers.filter(customer => !customer.customerKana.indexOf(this.syllabarySelect));
+                        customers = customers.filter(customer =>
+                        (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord) ||
+                            String(customer.customerKana)?.includes(this.searchCustomerWord)));
                         return customers;
                     },
                     // バリデーション

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -880,9 +880,9 @@
                             customers = customers.filter(customer => customer.isHide === false);
                         if (this.isShowFavorite === true)
                             customers = customers.filter(customer => customer.isFavorite === true);
-                        return customers.filter(customer => {
-                            return (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord));
-                        });
+                        customers = customers.filter(customer => (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord) ||
+                            String(customer.customerKana)?.includes(this.searchCustomerWord)));
+                        return customers;
                     },
                     // 商品選択モーダルの検索機能
                     searchItems: function () {

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -737,9 +737,9 @@
                             customers = customers.filter(customer => customer.isHide === false);
                         if (this.isShowFavorite === true)
                             customers = customers.filter(customer => customer.isFavorite === true);
-                        return customers.filter(customer => {
-                            return (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord));
-                        });
+                        customers = customers.filter(customer => (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord) ||
+                            String(customer.customerKana)?.includes(this.searchCustomerWord)));
+                        return customers;
                     },
                     // 商品選択モーダルの検索機能
                     searchItems: function () {


### PR DESCRIPTION
- ページネーションは廃止
- ID、得意先名、得意先カナで検索フィルターをかけた
- 得意先選択モーダルにも反映。

関連Issue：得意先ページネーション廃止。フリガナの頭文字で検索できる形にする。 #439