### PR TITLE
 請求・見積の新規作成・更新後はページ遷移せずに留まるように

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -505,7 +505,8 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="info" @click="modalShow(invoice,'upsertModal');" id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="bulkUpsert(invoice);showConfirmModal();"
+                            id="showUpsertModal">適用
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(invoice,'copyModal');"><i class="fa-solid fa-copy"></i></b-button>
@@ -525,11 +526,9 @@
                 </b-row>
             </b-card>
 
-            <!-- 保存モーダル -->
-            <div>
-                <select-modal modal-name='upsertModal' modal-message='保存しますか？'
-                    @selected="upsertModalProcess($event);" />
-            </div>
+            <!-- 確認モーダル -->
+            <confirm-modal :title="title" :message="message"></confirm-modal>
+
             <!-- コピーモーダル -->
             <div>
                 <select-modal modal-name='copyModal' modal-message='複製しますか？' @selected="copyModalProcess($event);" />
@@ -580,7 +579,9 @@
                         file: '',
                         fileId: ''
                     },
-                    uploadListMode: 'list' //list,card
+                    uploadListMode: 'list', //list,card
+                    title: '',      //モーダルタイトル
+                    message: '',    //モーダルメッセージ
                 },
                 methods: {
                     // ---Invoices---
@@ -605,16 +606,19 @@
                         await axios.post("/invoice", item)
                             .then(function (response) {
                                 Vue.set(self.invoice, 'id', response.data.id)
-                                self.getInvoices();
                                 self.invoice.isInsert = false;
+                                self.getInvoice(self.invoice);
+                                app.title = '新規作成';
+                                app.message = '保存しました。';
                             });
                     },
                     updateInvoice: async function (item) {
                         self = this;
                         await axios.put("/invoice/" + item.id, item)
                             .then(function (response) {
-                                self.getInvoices();
                                 console.log(response);
+                                app.title = '更新';
+                                app.message = '更新しました。'
                             });
                     },
                     copyInvoice: function (item) {
@@ -755,16 +759,13 @@
                         console.log(this.invoice);
                         this.$bvModal.show(modalName);
                     },
+                    showConfirmModal: function () {
+                        this.$bvModal.show('confirmModal');
+                    },
                     deleteModalProcess(result) {
                         this.$bvModal.hide('deleteModal');
                         if (result === true) {
                             this.deleteInvoice(this.invoice);
-                        }
-                    },
-                    upsertModalProcess(result) {
-                        this.$bvModal.hide('upsertModal');
-                        if (result === true) {
-                            this.bulkUpsert(this.invoice);
                         }
                     },
                     copyModalProcess(result) {

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -605,9 +605,11 @@
                         self = this;
                         await axios.post("/invoice", item)
                             .then(function (response) {
+                                console.log(response);
                                 Vue.set(self.invoice, 'id', response.data.id)
                                 self.invoice.isInsert = false;
                                 self.getInvoice(self.invoice);
+                                localStorage.setItem('invoice', JSON.stringify(self.invoice));
                                 app.title = '新規作成';
                                 app.message = '保存しました。';
                             });
@@ -617,8 +619,10 @@
                         await axios.put("/invoice/" + item.id, item)
                             .then(function (response) {
                                 console.log(response);
+                                self.getInvoice(self.invoice);
+                                localStorage.setItem('invoice', JSON.stringify(self.invoice));
                                 app.title = '更新';
-                                app.message = '更新しました。'
+                                app.message = '保存しました。'
                             });
                     },
                     copyInvoice: function (item) {

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -392,7 +392,8 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="info" @click="modalShow(quotation,'upsertModal');" id="showUpsertModal">
+                        <b-button pill variant="info" @click="bulkUpsert(quotation);showConfirmModal();"
+                            id="showConfirmModal">
                             適用
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
@@ -413,11 +414,9 @@
                 </b-row>
             </b-card>
 
-            <!-- 保存モーダル -->
-            <div>
-                <select-modal modal-name='upsertModal' modal-message='保存しますか？'
-                    @selected="upsertModalProcess($event);" />
-            </div>
+            <!-- 確認モーダル -->
+            <confirm-modal :title="title" :message="message"></confirm-modal>
+
             <!-- コピーモーダル -->
             <div>
                 <select-modal modal-name='copyModal' modal-message='複製しますか？' @selected="copyModalProcess($event);" />
@@ -462,6 +461,8 @@
                     makers: [],
                     isShowAll: false,        // trueの時、customer.isHide=falseのもののみindexに表示
                     isShowFavorite: false,
+                    title: '',      //モーダルタイトル
+                    message: '',    //モーダルメッセージ
                 },
                 methods: {
                     // ---Quotations---
@@ -485,17 +486,24 @@
                         self = this;
                         await axios.post("/quotation", item)
                             .then(function (response) {
+                                console.log(response);
                                 Vue.set(self.quotation, 'id', response.data.id)
-                                self.getQuotations();
                                 self.quotation.isInsert = false;
+                                self.getQuotation(self.quotation);
+                                localStorage.setItem('quotation', JSON.stringify(self.quotation));
+                                app.title = '新規作成';
+                                app.message = '保存しました。';
                             });
                     },
                     updateQuotation: async function (item) {
                         self = this;
                         await axios.put("/quotation/" + item.id, item)
                             .then(function (response) {
-                                self.getQuotations();
                                 console.log(response);
+                                self.getQuotation(self.quotation);
+                                localStorage.setItem('quotation', JSON.stringify(self.quotation));
+                                app.title = '更新';
+                                app.message = '保存しました。'
                             });
                     },
                     copyQuotation: function (item) {
@@ -635,16 +643,13 @@
                         console.log(this.quotation);
                         this.$bvModal.show(modalName);
                     },
+                    showConfirmModal: function () {
+                        this.$bvModal.show('confirmModal');
+                    },
                     deleteModalProcess(result) {
                         this.$bvModal.hide('deleteModal');
                         if (result === true) {
                             this.deleteQuotation(this.quotation);
-                        }
-                    },
-                    upsertModalProcess(result) {
-                        this.$bvModal.hide('upsertModal');
-                        if (result === true) {
-                            this.bulkUpsert(this.quotation);
                         }
                     },
                     copyModalProcess(result) {


### PR DESCRIPTION
関連Issue：請求・見積の新規・更新画面。保存時の選択モーダル撤廃。 #500

新規・更新時に一覧に戻るようにしていたが、留まるように変更。
新規作成後にブラウザの更新→入力してデータ更新しようとするとエラーがでるので後で原因を探る。
ローカルストレージへの保存がうまくいってないっぽい。