### PR TITLE
請求の入金日レイアウト修正。見積の備考欄配置修正。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -475,17 +475,14 @@
 
                         <b-row>
                             <b-col sm>
-                                <b-row>
+                                <b-row class="mb-3">
                                     <b-col cols="auto">
                                         <b-form-checkbox class="mr-3" v-model="invoice.isPaid">入金済み</b-form-checkbox>
                                     </b-col>
                                     <b-col>
-                                        <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="入金日"
-                                            label-for="paymentDate">
-                                            <b-form-input v-model="invoice.paymentDate" id="paymentDate" size="sm"
-                                                type="date">
-                                            </b-form-input>
-                                        </b-form-group>
+                                        <b-form-input v-model="invoice.paymentDate" id="paymentDate" size="sm"
+                                            type="date" style="width: 150px;">
+                                        </b-form-input>
                                     </b-col>
                                 </b-row>
                                 <b-form-textarea v-model="invoice.remarks" id="remarks" size="sm" type="text" rows="3"

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -207,8 +207,21 @@
                         <div class="mt-5"></div>
 
                         <b-row>
-                            <b-col></b-col>
-                            <b-col>
+                            <b-col sm class="ml-3">
+                                <b-row class="mb-3">
+                                    <b-col cols="auto">
+                                        <b-form-checkbox class="mr-3" v-model="invoice.isPaid">入金済み</b-form-checkbox>
+                                    </b-col>
+                                    <b-col>
+                                        <p class="text-left">{{invoice.paymentDate}}</p>
+                                    </b-col>
+                                </b-row>
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="備考欄"
+                                    label-for="remarks">
+                                    <p class="text-left pl-2" id="remarks">{{invoice.remarks}}</p>
+                                </b-form-group>
+                            </b-col>
+                            <b-col sm>
                                 <b-table-simple bordered>
                                     <b-form-checkbox v-model="invoice.isTaxExp">外税</b-form-checkbox>
                                     <b-tr>
@@ -223,12 +236,6 @@
                                 </b-table-simple>
                             </b-col>
                         </b-row>
-
-                        <!-- 備考欄 -->
-                        <b-card border-variant="white" class="mb-3 text-center" header="備考欄"
-                            header-border-variant="light">
-                            <p class="text-left">{{invoice.remarks}}</p>
-                        </b-card>
 
                     </b-col> <!-- 本体 -->
                     <b-col></b-col>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -365,8 +365,12 @@
                         <div class="mt-5"></div>
 
                         <b-row>
-                            <b-col></b-col>
-                            <b-col>
+                            <b-col sm>
+                                <b-form-textarea v-model="quotation.remarks" class="mt-5" id="remarks" size="sm"
+                                    type="text" rows="3" placeholder="備考欄">
+                                </b-form-textarea>
+                            </b-col>
+                            <b-col sm>
                                 <b-table-simple bordered>
                                     <b-form-checkbox v-model="quotation.isTaxExp">外税</b-form-checkbox>
                                     <b-tr>
@@ -381,13 +385,6 @@
                                 </b-table-simple>
                             </b-col>
                         </b-row>
-
-                        <!-- 備考欄 -->
-                        <b-card border-variant="white" class="mb-3 text-center" header="備考欄"
-                            header-border-variant="light">
-                            <b-form-textarea v-model="quotation.remarks" id="remarks" size="sm" type="text" rows="3">
-                            </b-form-textarea>
-                        </b-card>
 
                     </b-col> <!-- 本体 -->
                     <b-col></b-col>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -207,8 +207,13 @@
                         <div class="mt-5"></div>
 
                         <b-row>
-                            <b-col></b-col>
-                            <b-col>
+                            <b-col sm class="ml-3">
+                                <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="備考欄"
+                                    label-for="remarks" class="mt-5">
+                                    <p class="text-left pl-2" id="remarks">{{quotation.remarks}}</p>
+                                </b-form-group>
+                            </b-col>
+                            <b-col sm>
                                 <b-table-simple bordered>
                                     <b-form-checkbox v-model="quotation.isTaxExp">外税</b-form-checkbox>
                                     <b-tr>
@@ -223,12 +228,6 @@
                                 </b-table-simple>
                             </b-col>
                         </b-row>
-
-                        <!-- 備考欄 -->
-                        <b-card border-variant="white" class="mb-3 text-center" header="備考欄"
-                            header-border-variant="light">
-                            <p class="text-left">{{quotation.remarks}}</p>
-                        </b-card>
 
                     </b-col> <!-- 本体 -->
                     <b-col></b-col>


### PR DESCRIPTION
関連Issue：請求書の入金日入力欄。レイアウト変更。 #537
見積書の備考入力欄も左横に表示 #536