### PR TITLE
アップロード画面のレイアウト微修正

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -35,7 +35,7 @@
             .box {
                 /* border: 1px solid #333333; */
                 /* width: 200px; */
-                height: 200px;
+                height: 135px;
                 overflow-y: scroll;
             }
 
@@ -604,7 +604,7 @@
                         file: '',
                         fileId: ''
                     },
-                    uploadListMode: 'list', //list,card
+                    uploadListMode: 'card', //list,card
                     title: '',      //モーダルタイトル
                     message: '',    //モーダルメッセージ
                 },

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -15,7 +15,7 @@
             .box {
                 /* border: 1px solid #333333; */
                 /* width: 200px; */
-                height: 200px;
+                height: 135px;
                 overflow-y: scroll;
             }
 


### PR DESCRIPTION
関連Issue：アップロード一覧の高さはもっと狭く。card表示をデフォルトとする。 #494 

- 商品と請求書のアップロードリストの高さを調整
- 請求書ページでアップロードリストはデフォルトでカード表示になるように変更