### PR TITLE
「適用」ボタンを「保存」に変更

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -527,7 +527,7 @@
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
                         <b-button pill variant="info" @click="bulkUpsert(invoice);showConfirmModal();"
-                            id="showUpsertModal">適用
+                            id="showUpsertModal">保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(invoice,'copyModal');"><i class="fa-solid fa-copy"></i></b-button>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -410,7 +410,7 @@
                     <b-col class="text-right" md="auto" cols="auto">
                         <b-button pill variant="info" @click="bulkUpsert(quotation);showConfirmModal();"
                             id="showConfirmModal">
-                            適用
+                            保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(quotation,'copyModal');"><i class="fa-solid fa-copy"></i></b-button>


### PR DESCRIPTION
関連Issue：請求・見積書の新規・更新画面。「適用」ではなく「保存」ボタンにする #499