### PR TITLE
メモ一覧の日付位置変更

### DIFF
--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -36,10 +36,10 @@
                                 :items=memos :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
+                          {  key: 'createdAt', label: '作成日' },
                           {  key: 'title', label: '件名' },
                           {  key: 'manager', label: '担当者' },
                           {  key: 'content', label: '内容' },
-                          {  key: 'createdAt', label: '作成日時' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">


### PR DESCRIPTION
関連Issue：メモ一覧。作成日時→作成日＋配置変更 #456

メモ一覧の日付を一番左に変更。