### PR TITLE
請求・見積書新規作成後にブラウザ更新すると保存できないバグ修正

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -254,11 +254,11 @@ def invoice_create():
             data.get('deadLine'), "%Y-%m-%d") if data.get('deadLine') else None,
         paymentDate=datetime.strptime(
             data.get('paymentDate'), "%Y-%m-%d") if data.get('paymentDate') else None,
-        isPaid=data.get('isPaid'),
+        isPaid=data.get('isPaid') if data.get('isPaid') else False,
         title=data.get('title'),
         memo=data.get('memo'),
         remarks=data.get('remarks'),
-        isTaxExp=data.get('isTaxExp'),
+        isTaxExp=data.get('isTaxExp') if data.get('isTaxExp') else True,
         invoice_items=newInvoiceItems,
     )
     db.session.add(newInvoice)
@@ -287,11 +287,11 @@ def invoice_update(id):
         data.get('deadLine'), "%Y-%m-%d") if data.get('deadLine') else None
     invoice.paymentDate = datetime.strptime(
         data.get('paymentDate'), "%Y-%m-%d") if data.get('paymentDate') else None
-    invoice.isPaid = data.get('isPaid')
+    invoice.isPaid = data.get('isPaid') if data.get('isPaid') else False
     invoice.title = data.get('title')
     invoice.memo = data.get('memo')
     invoice.remarks = data.get('remarks')
-    invoice.isTaxExp = data.get('isTaxExp')
+    invoice.isTaxExp = data.get('isTaxExp') if data.get('isTaxExp') else True
 
     if data.get('invoice_items'):
         update_list = []
@@ -444,7 +444,7 @@ def quotation_create():
         title=data.get('title'),
         memo=data.get('memo'),
         remarks=data.get('remarks'),
-        isTaxExp=data.get('isTaxExp'),
+        isTaxExp=data.get('isTaxExp') if data.get('isTaxExp') else True,
         quotation_items=newQuotationItems,
     )
     db.session.add(newQuotation)
@@ -474,7 +474,7 @@ def quotation_update(id):
     quotation.title = data.get('title')
     quotation.memo = data.get('memo')
     quotation.remarks = data.get('remarks')
-    quotation.isTaxExp = data.get('isTaxExp')
+    quotation.isTaxExp = data.get('isTaxExp') if data.get('isTaxExp') else True
 
     if data.get('quotation_items'):
         update_list = []

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -273,16 +273,15 @@
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
-                                        label="アップロード" label-for="upform">
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="アップロード"
+                                        label-for="upform">
                                         <b-form @submit="uploadFile" id="upform">
                                             <b-input-group block>
                                                 <b-form-file v-model="form.file" browse-text="+"
-                                                    placeholder="クリックまたはドラッグ..."
-                                                    drop-placeholder="Drop file here...">
+                                                    placeholder="クリックまたはドラッグ..." drop-placeholder="Drop file here...">
                                                 </b-form-file>
                                                 <b-button pill type="submit" class="ml-3">確定</b-button>
-                                            </b-input-group>                                        
+                                            </b-input-group>
                                         </b-form>
                                     </b-form-group>
                                     <b-row>
@@ -676,8 +675,9 @@
                             invoice_items: [{}, {}, {}, {}, {}],
                         });
                         self.invoice = self.invoices.slice(-1)[0];
-                        localStorage.setItem('invoice', JSON.stringify(self.invoice));
                         Vue.set(self.invoice, 'isTaxExp', true);
+                        Vue.set(self.invoice, 'isPaid', false);
+                        localStorage.setItem('invoice', JSON.stringify(self.invoice));
                         this.clearFileList();
                     },
                     selectInvoice: function (item) {
@@ -927,9 +927,9 @@
                                 self.dicFiles = response.data;
                             })
                     },
-                    clearFileList: function(){
+                    clearFileList: function () {
                         this.dicFiles = {};
-                    },                    
+                    },
                     uploadFile: function (event) {
                         self = this;
                         event.preventDefault();

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -551,8 +551,8 @@
                             quotation_items: [{}, {}, {}, {}, {}],
                         });
                         self.quotation = self.quotations.slice(-1)[0];
-                        localStorage.setItem('quotation', JSON.stringify(self.quotation));
                         Vue.set(self.quotation, 'isTaxExp', true);
+                        localStorage.setItem('quotation', JSON.stringify(self.quotation));
                     },
                     selectQuotation: function (item) {
                         this.quotation = item;


### PR DESCRIPTION
関連Issue：請求・見積ページ。新規作成後にブラウザの更新をすると保存できない。 #535

とりあえずバグは出なくなったのだが、新たにバグを発見したのでまたIssueに書き出す。