### PR TITLE
請求・見積の日付検索、日にちでも検索できるように＋レイアウト修正

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -109,16 +109,18 @@
                             header-border-variant="light">
                             <b-row>
                                 <b-col sm>
-                                    <b-form-group sm label-cols="2" label-size="sm" label-align="center" label="検索"
-                                        label-for="searchInvoiceWord">
+                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label-align="left"
+                                        label="検索" label-for="searchInvoiceWord">
                                         <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
+                                <div class="ml-5"></div>
                                 <b-col sm>
-                                    <b-form-group label-cols="6" label-cols-lg="6" label-size="sm" label="日付"
-                                        label-for="searchApplyDate">
-                                        <b-form-input v-model="searchApplyDate" size="sm" placeholder="半角数字6桁">
+                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label-align="left"
+                                        label="日付" label-for="searchApplyDate">
+                                        <b-form-input v-model="searchApplyDate" size="sm" placeholder="半角数字6桁か8桁"
+                                            style="width: 50%;">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -1074,6 +1076,9 @@
                     return false;
                 }
                 if (searchDate.length === 6 && String(targetDate.slice(0, 4) + targetDate.slice(5, 7)) === String(searchDate)) {
+                    return true;
+                }
+                if (searchDate.length === 8 && String(targetDate.slice(0, 4) + targetDate.slice(5, 7) + targetDate.slice(8, 10)) === String(searchDate)) {
                     return true;
                 }
                 return false;

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -79,18 +79,22 @@
                             header-border-variant="light">
                             <b-row>
                                 <b-col sm>
-                                    <b-form-group sm label-cols="2" label-size="sm" label-align="center" label="検索"
-                                        label-for="searchQuotationWord">
+                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label-align="left"
+                                        label="検索" label-for="searchQuotationWord">
                                         <b-form-input v-model="searchQuotationWord" id="searchQuotationWord" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
+                                <div class="ml-5"></div>
                                 <b-col sm>
-                                    <b-form-group label-cols="6" label-cols-lg="6" label-size="sm" label="日付"
-                                        label-for="searchApplyDate">
-                                        <b-form-input v-model="searchApplyDate" size="sm" placeholder="半角数字6桁">
+                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label-align="left"
+                                        label="日付" label-for="searchApplyDate">
+                                        <b-form-input v-model="searchApplyDate" size="sm" placeholder="半角数字6桁か8桁"
+                                            style="width: 50%;">
                                         </b-form-input>
                                     </b-form-group>
+                                </b-col>
+                                <b-col sm>
                                 </b-col>
                             </b-row>
                             <b-row align-h="end">
@@ -875,6 +879,9 @@
                     return false;
                 }
                 if (searchDate.length === 6 && String(targetDate.slice(0, 4) + targetDate.slice(5, 7)) === String(searchDate)) {
+                    return true;
+                }
+                if (searchDate.length === 8 && String(targetDate.slice(0, 4) + targetDate.slice(5, 7) + targetDate.slice(8, 10)) === String(searchDate)) {
                     return true;
                 }
                 return false;


### PR DESCRIPTION
関連Issue：請求・見積書一覧。日付検索は月だけじゃなく日にちでも＋レイアウト修正 #596

- 最大８桁で日付検索できるようにした。
- 日付検索入力欄の幅を狭くした。