### PR TITLE
b-tableの上下ズレ修正。レイアウト修正。

### DIFF
--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -1,5 +1,11 @@
 <% extends "head.html" %>
     <% block content %>
+        <style>
+            #categorytable td {
+                vertical-align: middle;
+            }
+        </style>
+
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -12,6 +12,10 @@
             .td-telNumber {
                 width: 120px;
             }
+
+            #customertable td {
+                vertical-align: middle;
+            }
         </style>
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
@@ -46,14 +50,15 @@
                         <b-card border-variant="white" class="mb-3 text-center" header="得意先一覧"
                             header-border-variant="light">
                             <b-row>
-                                <b-col>
-                                    <b-form-group sm label-cols="2" label-size="sm" label-align="center" label="検索"
-                                        label-for="searchCustomerWord">
+                                <b-col sm>
+                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label-align="left"
+                                        label="検索" label-for="searchCustomerWord">
                                         <b-form-input v-model="searchCustomerWord" id="searchCustomerWord" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
-                                <b-col>
+                                <b-col sm></b-col>
+                                <b-col sm>
                                     <b-row align-h="end">
                                         <b-form-checkbox class="mr-3" v-model="isShowFavorite">お気に入り</b-form-checkbox>
                                         <b-form-checkbox class="mr-3" v-model="isShowAll">全て表示</b-form-checkbox>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -4,6 +4,11 @@
         <link href="https://printjs-4de6.kxcdn.com/print.min.css" rel="stylesheet">
 
         <style>
+            #invoicetable td,
+            #invoice_items_table td {
+                vertical-align: middle;
+            }
+
             .td-item-id {
                 width: 90px;
             }
@@ -147,12 +152,10 @@
                                     </router-link>
                                 </template>
                                 <template v-slot:cell(applyDate)="data">
-                                    <p class="text-left pl-2" id="applyDate">{{formatDate(data.item.applyDate)}}</p>
+                                    {{formatDate(data.item.applyDate)}}
                                 </template>
                                 <template v-slot:cell(totalAmount)="data">
-                                    <p class="text-left pl-2" id="totalAmount">
-                                        {{amountCalculation(data.item)|nf}}
-                                    </p>
+                                    {{amountCalculation(data.item)|nf}}
                                 </template>
                             </b-table>
                         </b-card>
@@ -422,7 +425,7 @@
                                 </b-form-input>
                             </template>
                             <template v-slot:cell(amount)="data">
-                                <p class="text-right">{{data.item.count*data.item.price|nf}}</p>
+                                <div class="text-right">{{data.item.count*data.item.price|nf}}</div>
                             </template>
 
                             <template v-slot:cell(detail)="data">

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -1,6 +1,11 @@
 <% extends "head.html" %>
     <% block content %>
         <style>
+            #invoicetable td,
+            #invoice_items_table td {
+                vertical-align: middle;
+            }
+
             .td-item-id {
                 width: 90px;
             }
@@ -68,13 +73,13 @@
                                     </router-link>
                                 </template>
                                 <template v-slot:cell(applyDate)="data">
-                                    <p class="text-left pl-2" id="applyDate">{{formatDate(data.item.applyDate)}}</p>
+                                    {{formatDate(data.item.applyDate)}}
                                 </template>
                                 <template v-slot:cell(deadLine)="data">
-                                    <p class="text-left pl-2" id="deadLine">{{formatDate(data.item.deadLine)}}</p>
+                                    {{formatDate(data.item.deadLine)}}
                                 </template>
                                 <template v-slot:cell(updatedAt)="data">
-                                    <p class="text-left pl-2" id="updatedAt">{{formatDateTime(data.item.updatedAt)}}</p>
+                                    {{formatDateTime(data.item.updatedAt)}}
                                 </template>
                             </b-table>
                         </b-card>
@@ -188,19 +193,19 @@
                           {  key: 'detail', label: '詳細',class:'text-center' },
                         ]">
                             <template v-slot:cell(itemName)="data">
-                                <p>{{data.item.itemName}}</p>
+                                {{data.item.itemName}}
                             </template>
                             <template v-slot:cell(count)="data">
-                                <p>{{data.item.count}}</p>
+                                {{data.item.count}}
                             </template>
                             <template v-slot:cell(unit)="data">
-                                <p>{{data.item.unit}}</p>
+                                {{data.item.unit}}
                             </template>
                             <template v-slot:cell(price)="data">
-                                <p>{{data.item.price}}</p>
+                                {{data.item.price}}
                             </template>
                             <template v-slot:cell(amount)="data">
-                                <p class="text-right">{{data.item.count*data.item.price|nf}}</p>
+                                {{data.item.count*data.item.price|nf}}
                             </template>
 
                             <template v-slot:cell(detail)="data">

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -4,12 +4,8 @@
         <script src="https://unpkg.com/vue-select@3.0.0"></script>
         <link rel="stylesheet" href="https://unpkg.com/vue-select@3.0.0/dist/vue-select.css">
         <style>
-            .td-postNumber {
-                width: 80px;
-            }
-
-            .td-telNumber {
-                width: 120px;
+            #itemtable td {
+                vertical-align: middle;
             }
 
             .box {

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -1,5 +1,10 @@
 <% extends "head.html" %>
     <% block content %>
+        <style>
+            #makertable td {
+                vertical-align: middle;
+            }
+        </style>
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -1,5 +1,10 @@
 <% extends "head.html" %>
     <% block content %>
+        <style>
+            #memotable td {
+                vertical-align: middle;
+            }
+        </style>
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
@@ -49,7 +54,7 @@
                                     </router-link>
                                 </template>
                                 <template v-slot:cell(createdAt)="data">
-                                    <p class="text-left pl-2" id="createdAt">{{formatDate(data.item.createdAt)}}</p>
+                                    {{formatDate(data.item.createdAt)}}
                                 </template>
                             </b-table>
                         </b-card>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -4,6 +4,11 @@
         <link href="https://printjs-4de6.kxcdn.com/print.min.css" rel="stylesheet">
 
         <style>
+            #quotationtable td,
+            #quotation_items_table td {
+                vertical-align: middle;
+            }
+
             .td-item-id {
                 width: 90px;
             }
@@ -114,12 +119,10 @@
                                     </router-link>
                                 </template>
                                 <template v-slot:cell(applyDate)="data">
-                                    <p class="text-left pl-2" id="applyDate">{{formatDate(data.item.applyDate)}}</p>
+                                    {{formatDate(data.item.applyDate)}}
                                 </template>
                                 <template v-slot:cell(totalAmount)="data">
-                                    <p class="text-left pl-2" id="totalAmount">
-                                        {{amountCalculation(data.item)|nf}}
-                                    </p>
+                                    {{amountCalculation(data.item)|nf}}
                                 </template>
                             </b-table>
                         </b-card>
@@ -317,7 +320,7 @@
                                 <b-form-input v-model="data.item.price" type="number" size="sm"></b-form-input>
                             </template>
                             <template v-slot:cell(amount)="data">
-                                <p class="text-right">{{data.item.count*data.item.price|nf}}</p>
+                                <div class="text-right">{{data.item.count*data.item.price|nf}}</div>
                             </template>
 
                             <template v-slot:cell(detail)="data">

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -1,6 +1,11 @@
 <% extends "head.html" %>
     <% block content %>
         <style>
+            #quotationtable td,
+            #quotation_items_table td {
+                vertical-align: middle;
+            }
+
             .td-item-id {
                 width: 90px;
             }
@@ -68,13 +73,13 @@
                                     </router-link>
                                 </template>
                                 <template v-slot:cell(applyDate)="data">
-                                    <p class="text-left pl-2" id="applyDate">{{formatDate(data.item.applyDate)}}</p>
+                                    {{formatDate(data.item.applyDate)}}
                                 </template>
                                 <template v-slot:cell(expiry)="data">
-                                    <p class="text-left pl-2" id="expiry">{{formatDate(data.item.expiry)}}</p>
+                                    {{formatDate(data.item.expiry)}}
                                 </template>
                                 <template v-slot:cell(updatedAt)="data">
-                                    <p class="text-left pl-2" id="updatedAt">{{formatDateTime(data.item.updatedAt)}}</p>
+                                    {{formatDateTime(data.item.updatedAt)}}
                                 </template>
                             </b-table>
                         </b-card>
@@ -188,19 +193,19 @@
                           {  key: 'detail', label: '詳細',class:'text-center' },
                         ]">
                             <template v-slot:cell(itemName)="data">
-                                <p>{{data.item.itemName}}</p>
+                                {{data.item.itemName}}
                             </template>
                             <template v-slot:cell(count)="data">
-                                <p>{{data.item.count}}</p>
+                                {{data.item.count}}
                             </template>
                             <template v-slot:cell(unit)="data">
-                                <p>{{data.item.unit}}</p>
+                                {{data.item.unit}}
                             </template>
                             <template v-slot:cell(price)="data">
-                                <p>{{data.item.price}}</p>
+                                {{data.item.price}}
                             </template>
                             <template v-slot:cell(amount)="data">
-                                <p class="text-right">{{data.item.count*data.item.price|nf}}</p>
+                                {{data.item.count*data.item.price|nf}}
                             </template>
 
                             <template v-slot:cell(detail)="data">

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -1,5 +1,11 @@
 <% extends "head.html" %>
     <% block content %>
+        <style>
+            #unittable td {
+                vertical-align: middle;
+            }
+        </style>
+
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -1,5 +1,11 @@
 <% extends "head.html" %>
     <% block content %>
+        <style>
+            #usertable td {
+                vertical-align: middle;
+            }
+        </style>
+
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">


### PR DESCRIPTION
関連Issue：一覧ページまとめ #583

- 一覧画面の検索ラベル左揃え
- b-table内のtdにmiddleを付与。行の要素上下中央揃えに。