### PR TITLE
全ページの新規・更新画面。フッターのコントロールボタンにポッパーを適用

### DIFF
--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -110,16 +110,19 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getCategories();">＜</b-button>
+                            <b-button @click="getCategories();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="modalShow(category,'upsertModal');" id="showUpsertModal">
+                        <b-button pill variant="info" @click="modalShow(category,'upsertModal');"
+                            v-b-tooltip.hover.top="'適用'">
                             適用
                         </b-button>
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" v-b-tooltip.hover.top="'印刷'">
+                            <i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(category,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(category,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -204,7 +204,7 @@
                             </b-row>
                             <b-row>
                                 <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ホームページURL"
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="サイトURL"
                                         label-for="url">
                                         <b-form-input v-model="customer.url" id="url" size="sm" autocomplete="off">
                                         </b-form-input>
@@ -295,13 +295,15 @@
                 class="fixed-bottom footer">
                 <b-row>
                     <b-col>
-                        <b-button @click="checkChange">＜</b-button>
+                        <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="apply();">適用</b-button>
-                        <b-button pill size="lg" variant="info" @click="pdfOut"><i class="fas fa-print"></i>
+                        <b-button pill variant="info" @click="apply();" v-b-tooltip.hover.top="'適用'">適用</b-button>
+                        <b-button pill size="lg" variant="info" @click="pdfOut" v-b-tooltip.hover.top="'印刷'"><i
+                                class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(customer,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(customer,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -287,7 +287,7 @@
                                                     placeholder="クリックまたはドラッグ..." drop-placeholder="Drop file here...">
                                                 </b-form-file>
                                                 <b-button pill type="submit" class="ml-3">
-                                                    <span  v-if="!isUploading">確定</span>
+                                                    <span v-if="!isUploading">確定</span>
                                                     <b-spinner v-else label="Spinning" small></b-spinner>
                                                 </b-button>
                                             </b-input-group>
@@ -524,24 +524,28 @@
                 class="fixed-bottom footer">
                 <b-row>
                     <b-col>
-                        <b-button @click="checkChange">＜</b-button>
+                        <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
                         <b-button pill variant="info" @click="bulkUpsert(invoice);showConfirmModal();"
-                            id="showUpsertModal">保存
+                            v-b-tooltip.hover.top="'保存'">保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
-                            @click="modalShow(invoice,'copyModal');"><i class="fa-solid fa-copy"></i></b-button>
+                            @click="modalShow(invoice,'copyModal');" v-b-tooltip.hover.top="'複製'"><i
+                                class="fa-solid fa-copy"></i></b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="convert-button"
-                            @click="modalShow(invoice,'convertModal');"><i class="fa-solid fa-shuffle"></i></b-button>
-                        <b-dropdown split dropup id="dropdown-dropup" size="lg" @click="pdfout('invoice')" id="pdfout">
+                            @click="modalShow(invoice,'convertModal');" v-b-tooltip.hover.top="'見積書に変換'"><i
+                                class="fa-solid fa-shuffle"></i></b-button>
+                        <b-dropdown split dropup id="dropdown-dropup" size="lg" @click="pdfout('invoice')" id="pdfout"
+                            v-b-tooltip.hover.top="'印刷'">
                             <template #button-content>
                                 <i class="fas fa-print"></i>
                             </template>
                             <b-dropdown-item @click="pdfout('delivery')">納品書</b-dropdown-item>
                             <b-dropdown-item @click="pdfoutRcpt">領収書</b-dropdown-item>
                         </b-dropdown>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(invoice,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(invoice,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -285,12 +285,12 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getInvoices();">＜</b-button>
+                            <b-button @click="getInvoices();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
                         <b-dropdown split dropup id="dropdown-dropup" size="lg" class="m-2" @click="alert('印刷しました。');"
-                            id="pdfout">
+                            id="pdfout" v-b-tooltip.hover.top="'印刷'">
                             <template #button-content>
                                 <i class="fas fa-print"></i>
                             </template>

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -325,14 +325,17 @@
                 class="fixed-bottom footer">
                 <b-row>
                     <b-col>
-                        <b-button @click="checkChange">＜</b-button>
+                        <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="modalShow(item,'upsertModal');" id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(item,'upsertModal');"
+                            v-b-tooltip.hover.top="'適用'">適用
                         </b-button>
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" v-b-tooltip.hover.top="'印刷'">
+                            <i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(item,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(item,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -107,15 +107,18 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getMakers();">＜</b-button>
+                            <b-button @click="getMakers();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="modalShow(maker,'upsertModal');" id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(maker,'upsertModal');"
+                            v-b-tooltip.hover.top="'適用'">適用
                         </b-button>
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" v-b-tooltip.hover.top="'印刷'">
+                            <i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(maker,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(maker,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -126,15 +126,18 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getMemos();">＜</b-button>
+                            <b-button @click="getMemos();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="modalShow(memo,'upsertModal');" id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(memo,'upsertModal');"
+                            v-b-tooltip.hover.top="'適用'">適用
                         </b-button>
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" v-b-tooltip.hover.top="'印刷'">
+                            <i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(memo,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(memo,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -406,20 +406,19 @@
                 class="fixed-bottom footer">
                 <b-row>
                     <b-col>
-                        <b-button @click="checkChange">＜</b-button>
+                        <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="info" @click="bulkUpsert(quotation);showConfirmModal();"
-                            id="showConfirmModal">
+                        <b-button pill variant="info" @click="bulkUpsert(quotation);showConfirmModal();" v-b-tooltip.hover.top="'保存'">
                             保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
-                            @click="modalShow(quotation,'copyModal');"><i class="fa-solid fa-copy"></i></b-button>
+                            @click="modalShow(quotation,'copyModal');" v-b-tooltip.hover.top="'複製'"><i class="fa-solid fa-copy"></i></b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="convert-button"
-                            @click="modalShow(quotation,'convertModal');"><i class="fa-solid fa-shuffle"></i></b-button>
-                        <b-button pill size="lg" variant="info" @click="pdfout" id="pdfout"><i class="fas fa-print"></i>
+                            @click="modalShow(quotation,'convertModal');" v-b-tooltip.hover.top="'請求書へ変換'"><i class="fa-solid fa-shuffle"></i></b-button>
+                        <b-button pill size="lg" variant="info" @click="pdfout" id="pdfout" v-b-tooltip.hover.top="'印刷'"><i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(quotation,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(quotation,'deleteModal');" v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -277,12 +277,12 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getQuotations();">＜</b-button>
+                            <b-button @click="getQuotations();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" id="pdfout"><i
-                                class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" id="pdfout"
+                            v-b-tooltip.hover.top="'印刷'"><i class="fas fa-print"></i>
                         </b-button>
                     </b-col>
                 </b-row>

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -224,13 +224,13 @@
                         <b-button href="/dust-select-page">削除済み参照</b-button>
                     </b-col>
                     <b-col class="sm-mode">
-                        <b-button href="/user-page">
+                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
                         </b-button>
-                        <b-button href="/unit-page">
+                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>
                         </b-button>
-                        <b-button href="/dust-select-page">
+                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
                             <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -108,15 +108,18 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getUnits();">＜</b-button>
+                            <b-button @click="getUnits();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="modalShow(unit,'upsertModal');" id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(unit,'upsertModal');"
+                            v-b-tooltip.hover.top="'適用'">適用
                         </b-button>
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" v-b-tooltip.hover.top="'印刷'">
+                            <i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(unit,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(unit,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -136,15 +136,18 @@
                 <b-row>
                     <b-col>
                         <router-link to="?page=index">
-                            <b-button @click="getUsers();">＜</b-button>
+                            <b-button @click="getUsers();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="info" @click="modalShow(user,'upsertModal');" id="showUpsertModal">適用
+                        <b-button pill variant="info" @click="modalShow(user,'upsertModal');"
+                            v-b-tooltip.hover.top="'適用'">適用
                         </b-button>
-                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')"><i class="fas fa-print"></i>
+                        <b-button pill size="lg" variant="info" @click="alert('印刷しました。')" v-b-tooltip.hover.top="'印刷'">
+                            <i class="fas fa-print"></i>
                         </b-button>
-                        <b-button pill size="lg" variant="danger" @click="modalShow(user,'deleteModal');">
+                        <b-button pill size="lg" variant="danger" @click="modalShow(user,'deleteModal');"
+                            v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
                         </b-button>
                     </b-col>


### PR DESCRIPTION
関連Issue：新規・更新画面まとめ #588

- フッターにポッパーを適用