### PR TITLE
商品一覧フィルターのカテゴリとメーカーの選択肢に空文字追加

### DIFF
--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -477,7 +477,8 @@
                         await axios.get('/categories')
                             .then(function (response) {
                                 console.log(response);
-                                self.categories = response.data.map(item => item['categoryName'])
+                                self.categories = response.data.map(item => item['categoryName']);
+                                self.categories.unshift('');
                             });
                     },
                     getMakers: async function () {
@@ -485,7 +486,8 @@
                         await axios.get('/makers')
                             .then(function (response) {
                                 console.log(response);
-                                self.makers = response.data.map(item => item['makerName'])
+                                self.makers = response.data.map(item => item['makerName']);
+                                self.makers.unshift('');
                             });
                     },
                     modalShow: function (item, modalName) {


### PR DESCRIPTION
関連Issue：商品一覧のフィルター用セレクトボックスに空欄を #637