### PR TITLE
全ページ新規・更新画面のラベルを右揃えに

### DIFF
--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -83,7 +83,7 @@
                             <b-row>
                                 <b-col>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="カテゴリ名"
-                                        label-for="categoryName">
+                                        label-for="categoryName" label-align="right">
                                         <b-form-input v-model="category.categoryName" id="categoryName" size="sm"
                                             autocomplete="off">
                                         </b-form-input>

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -121,7 +121,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="得意先名"
-                                        label-for="customerName">
+                                        label-for="customerName" label-align="right">
                                         <b-form-input v-model="customer.customerName" id="customerName" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -129,7 +129,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="敬称"
-                                        label-for="honorificTitle">
+                                        label-for="honorificTitle" label-align="right">
                                         <b-form-input v-model="customer.honorificTitle" id="honorificTitle" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -139,7 +139,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="フリガナ"
-                                        label-for="customerKana">
+                                        label-for="customerKana" label-align="right">
                                         <b-form-input id="input-live" v-model="customer.customerKana"
                                             :state="customerKanaValidate"
                                             aria-describedby="input-live-help input-live-feedback" trim></b-form-input>
@@ -151,7 +151,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department">
+                                        label-for="department" label-align="right">
                                         <b-form-input v-model="customer.department" id="department" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -161,7 +161,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="郵便番号"
-                                        label-for="postNumber">
+                                        label-for="postNumber" label-align="right">
                                         <b-form-input v-model="customer.postNumber" id="postNumber" size="sm"
                                             autocomplete="off" :formatter="formatter_postNum">
                                         </b-form-input>
@@ -174,7 +174,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="住所1"
-                                        label-for="address">
+                                        label-for="address" label-align="right">
                                         <b-form-input v-model="customer.address" id="address" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -182,7 +182,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="住所2"
-                                        label-for="address">
+                                        label-for="address" label-align="right">
                                         <b-form-input v-model="customer.addressSub" id="address" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -192,7 +192,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="電話番号"
-                                        label-for="telNumber">
+                                        label-for="telNumber" label-align="right">
                                         <b-form-input v-model="customer.telNumber" id="telNumber" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -200,7 +200,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="FAX番号"
-                                        label-for="faxNumber">
+                                        label-for="faxNumber" label-align="right">
                                         <b-form-input v-model="customer.faxNumber" id="faxNumber" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -210,14 +210,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="サイトURL"
-                                        label-for="url">
+                                        label-for="url" label-align="right">
                                         <b-form-input v-model="customer.url" id="url" size="sm" autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="email"
-                                        label-for="email">
+                                        label-for="email" label-align="right">
                                         <b-form-input v-model="customer.email" id="email" size="sm" autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
@@ -226,7 +226,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="代表者名"
-                                        label-for="representative">
+                                        label-for="representative" label-align="right">
                                         <b-form-input v-model="customer.representative" id="representative" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -234,7 +234,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager">
+                                        label-for="manager" label-align="right">
                                         <b-form-input v-model="customer.manager" id="manager" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -244,7 +244,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="お客様区分"
-                                        label-for="customerCategory">
+                                        label-for="customerCategory" label-align="right">
                                         <b-form-radio-group required v-if="" v-model="customer.customerCategory"
                                             id="customerCategory" :options="[
                                             {  text: '法人', value: 'corporation' },
@@ -252,11 +252,11 @@
                                             ]"></b-form-radio-group>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="非表示"
-                                        label-for="isHide">
+                                        label-for="isHide" label-align="right">
                                         <b-form-checkbox v-model="customer.isHide"></b-form-checkbox>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="お気に入り"
-                                        label-for="isFavorite">
+                                        label-for="isFavorite" label-align="right">
                                         <div v-if="customer.isFavorite===true">
                                             <a href="#" style="text-decoration: none;color:#fed11d;padding: 0 7px 0 0;"
                                                 @click="changeIsFavorite(customer.isFavorite);">
@@ -273,7 +273,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="memo">
+                                        label-for="memo" label-align="right">
                                         <b-form-textarea v-model="customer.memo" size="sm" rows="4">
                                         </b-form-textarea>
                                     </b-form-group>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -181,13 +181,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客ID"
-                                        label-for="customerId">
+                                        label-for="customerId" label-align="right">
                                         <p class="text-left pl-2" id="customerId">{{invoice.customerId}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="請求No."
-                                        label-for="applyNumber">
+                                        label-for="applyNumber" label-align="right">
                                         <p class="text-left pl-2" id="applyNumber">{{invoice.applyNumber}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -195,14 +195,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="日付"
-                                        label-for="applyDate">
+                                        label-for="applyDate" label-align="right">
                                         <b-form-input v-model="invoice.applyDate" id="applyDate" size="sm" type="date">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="支払期限"
-                                        label-for="deadLine">
+                                        label-for="deadLine" label-align="right">
                                         <b-form-input v-model="invoice.deadLine" id="deadLine" size="sm" type="date">
                                         </b-form-input>
                                     </b-form-group>
@@ -211,7 +211,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客名"
-                                        label-for="customer" class="customer">
+                                        label-for="customer" class="customer" label-align="right">
                                         <b-form-input v-model="invoice.customerName" id="customerName" size="sm"
                                             autocomplete="off" @dblclick="$bvModal.show('customer-modal')"
                                             v-on:keydown.enter="onKeyDownCustomer">
@@ -243,7 +243,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager">
+                                        label-for="manager" label-align="right">
                                         <b-form-input v-model="invoice.manager" id="manager" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
@@ -253,24 +253,24 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department">
+                                        label-for="department" label-align="right">
                                         <b-form-input v-model="invoice.department" id="department" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="先方担当者"
-                                        label-for="otherPartyManager">
+                                        label-for="otherPartyManager" label-align="right">
                                         <b-form-input v-model="invoice.otherPartyManager" id="otherPartyManager"
                                             size="sm" autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"
-                                        label-for="title">
+                                        label-for="title" label-align="right">
                                         <b-form-input v-model="invoice.title" id="title" size="sm" autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="メモ">
+                                        label-for="メモ" label-align="right">
                                         <b-form-textarea v-model="invoice.memo" size="sm" rows="2">
                                         </b-form-textarea>
                                     </b-form-group>

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -137,13 +137,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客ID"
-                                        label-for="customerId">
+                                        label-for="customerId" label-align="right">
                                         <p class="text-left pl-2" id="customerId">{{invoice.customerId}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="請求No."
-                                        label-for="applyNumber">
+                                        label-for="applyNumber" label-align="right">
                                         <p class="text-left pl-2" id="applyNumber">{{invoice.applyNumber}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -151,13 +151,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="日付"
-                                        label-for="applyDate">
+                                        label-for="applyDate" label-align="right">
                                         <p class="text-left pl-2" id="applyDate">{{formatDate(invoice.applyDate)}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="支払期限"
-                                        label-for="deadLine">
+                                        label-for="deadLine" label-align="right">
                                         <p class="text-left pl-2" id="deadLine">{{formatDate(invoice.deadLine)}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -165,13 +165,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客名"
-                                        label-for="customer" class="customer">
+                                        label-for="customer" class="customer" label-align="right">
                                         <p class="text-left pl-2" id="customerName">{{invoice.customerName}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager">
+                                        label-for="manager" label-align="right">
                                         <p class="text-left pl-2" id="manager">{{invoice.manager}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -179,13 +179,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department">
+                                        label-for="department" label-align="right">
                                         <p class="text-left pl-2" id="department">{{invoice.department}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="先方担当者"
-                                        label-for="otherPartyManager">
+                                        label-for="otherPartyManager" label-align="right">
                                         <p class="text-left pl-2" id="otherPartyManager">{{invoice.otherPartyManager}}
                                         </p>
                                     </b-form-group>
@@ -194,13 +194,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"
-                                        label-for="title">
+                                        label-for="title" label-align="right">
                                         <p class="text-left pl-2" id="title">{{invoice.title}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="memo">
+                                        label-for="memo" label-align="right">
                                         <p class="text-left pl-2" id="memo">{{invoice.memo}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -210,7 +210,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="削除日時"
-                                        label-for="updatedAt">
+                                        label-for="updatedAt" label-align="right">
                                         <p class="text-left pl-2" id="updatedAt">{{formatDateTime(invoice.updatedAt)}}
                                         </p>
                                     </b-form-group>

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -155,13 +155,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="商品名"
-                                        label-for="itemName">
+                                        label-for="itemName" label-align="right">
                                         <b-form-input v-model="item.itemName" id="itemName" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="商品コード"
-                                        label-for="itemCode">
+                                        label-for="itemCode" label-align="right">
                                         <b-form-input v-model="item.itemCode" id="itemCode" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -169,7 +169,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="カテゴリ"
-                                        label-for="category">
+                                        label-for="category" label-align="right">
                                         <b-form-input list="list-category" v-model="item.category" size="sm"
                                             autocomplete="off"></b-form-input>
                                         <datalist id="list-category">
@@ -182,7 +182,8 @@
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メーカー">
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メーカー"
+                                        label-align="right">
                                         <b-form-input list="list-maker" v-model="item.maker" size="sm"
                                             autocomplete="off"></b-form-input>
                                         <datalist id="list-maker">
@@ -194,7 +195,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単位"
-                                        label-for="unit">
+                                        label-for="unit" label-align="right">
                                         <b-form-input list="list-unit" v-model="item.unit" size="sm" autocomplete="off">
                                         </b-form-input>
                                         <datalist id="list-unit">
@@ -214,7 +215,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="型式"
-                                        label-for="model">
+                                        label-for="model" label-align="right">
                                         <b-form-input v-model="item.model" id="model" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -222,7 +223,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単価"
-                                        label-for="basePrice">
+                                        label-for="basePrice" label-align="right">
                                         <b-form-input v-model="item.basePrice" id="basePrice" size="sm" type="number">
                                         </b-form-input>
                                         </b-form-input>
@@ -230,7 +231,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単価原価"
-                                        label-for="baseCost">
+                                        label-for="baseCost" label-align="right">
                                         <b-form-input v-model="item.baseCost" id="baseCost" size="sm" type="number">
                                         </b-form-input>
                                     </b-form-group>
@@ -239,13 +240,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="メモ">
+                                        label-for="メモ" label-align="right">
                                         <b-form-textarea v-model="item.memo" size="sm" rows="6"></b-form-textarea>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="アップロード"
-                                        label-for="upform">
+                                        label-for="upform" label-align="right">
                                         <b-form @submit="uploadFile" id="upform" inline>
                                             <b-input-group block>
                                                 <b-form-file v-model="form.file" browse-text="+"

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -82,7 +82,7 @@
                             <b-row>
                                 <b-col>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メーカー名"
-                                        label-for="makerName">
+                                        label-for="makerName" label-align="right">
                                         <b-form-input v-model="maker.makerName" id="makerName" size="sm">
                                         </b-form-input>
                                     </b-form-group>

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -83,14 +83,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"
-                                        label-for="title">
+                                        label-for="title" label-align="right">
                                         <b-form-input v-model="memo.title" id="title" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager">
+                                        label-for="manager" label-align="right">
                                         <b-form-input v-model="memo.manager" id="manager" size="sm">
                                         </b-form-input>
                                     </b-form-group>
@@ -99,7 +99,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="内容"
-                                        label-for="content">
+                                        label-for="content" label-align="right">
                                         <b-form-textarea v-model="memo.content" size="sm" rows="10" max-rows="20">
                                         </b-form-textarea>
                                     </b-form-group>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -160,13 +160,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客ID"
-                                        label-for="customerId">
+                                        label-for="customerId" label-align="right">
                                         <p class="text-left pl-2" id="customerId">{{quotation.customerId}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="見積No."
-                                        label-for="applyNumber">
+                                        label-for="applyNumber" label-align="right">
                                         <p class="text-left pl-2" id="applyNumber">{{quotation.applyNumber}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -174,7 +174,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="日付"
-                                        label-for="applyDate">
+                                        label-for="applyDate" label-align="right">
                                         <b-form-input v-model="quotation.applyDate" id="applyDate" size="sm"
                                             type="date">
                                         </b-form-input>
@@ -182,7 +182,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="見積有効期限"
-                                        label-for="expiry">
+                                        label-for="expiry" label-align="right">
                                         <b-form-input v-model="quotation.expiry" id="expiry" size="sm" type="date">
                                         </b-form-input>
                                     </b-form-group>
@@ -191,7 +191,7 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客名"
-                                        label-for="customer" class="customer">
+                                        label-for="customer" class="customer" label-align="right">
                                         <b-form-input v-model="quotation.customerName" id="customerName" size="sm"
                                             @dblclick="$bvModal.show('customer-modal')"
                                             v-on:keydown.enter="onKeyDownCustomer">
@@ -222,7 +222,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager">
+                                        label-for="manager" label-align="right">
                                         <b-form-input v-model="quotation.manager" id="manager" size="sm">
                                         </b-form-input>
                                     </b-form-group>
@@ -231,24 +231,24 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department">
+                                        label-for="department" label-align="right">
                                         <b-form-input v-model="quotation.department" id="department" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="先方担当者"
-                                        label-for="otherPartyManager">
+                                        label-for="otherPartyManager" label-align="right">
                                         <b-form-input v-model="quotation.otherPartyManager" id="otherPartyManager"
                                             size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"
-                                        label-for="title">
+                                        label-for="title" label-align="right">
                                         <b-form-input v-model="quotation.title" id="title" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="メモ">
+                                        label-for="メモ" label-align="right">
                                         <b-form-textarea v-model="quotation.memo" size="sm" rows="2">
                                         </b-form-textarea>
                                     </b-form-group>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -138,13 +138,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客ID"
-                                        label-for="customerId">
+                                        label-for="customerId" label-align="right">
                                         <p class="text-left pl-2" id="customerId">{{quotation.customerId}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="見積No."
-                                        label-for="applyNumber">
+                                        label-for="applyNumber" label-align="right">
                                         <p class="text-left pl-2" id="applyNumber">{{quotation.applyNumber}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -152,13 +152,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="日付"
-                                        label-for="applyDate">
+                                        label-for="applyDate" label-align="right">
                                         <p class="text-left pl-2" id="applyDate">{{formatDate(quotation.applyDate)}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="見積有効期限"
-                                        label-for="expiry">
+                                        label-for="expiry" label-align="right">
                                         <p class="text-left pl-2" id="expiry">{{formatDate(quotation.expiry)}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -166,13 +166,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客名"
-                                        label-for="customer" class="customer">
+                                        label-for="customer" class="customer" label-align="right">
                                         <p class="text-left pl-2" id="customerName">{{quotation.customerName}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager">
+                                        label-for="manager" label-align="right">
                                         <p class="text-left pl-2" id="manager">{{quotation.manager}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -180,13 +180,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department">
+                                        label-for="department" label-align="right">
                                         <p class="text-left pl-2" id="department">{{quotation.department}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="先方担当者"
-                                        label-for="otherPartyManager">
+                                        label-for="otherPartyManager" label-align="right">
                                         <p class="text-left pl-2" id="otherPartyManager">{{quotation.otherPartyManager}}
                                         </p>
                                     </b-form-group>
@@ -195,13 +195,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"
-                                        label-for="title">
+                                        label-for="title" label-align="right">
                                         <p class="text-left pl-2" id="title">{{quotation.title}}</p>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="memo">
+                                        label-for="memo" label-align="right">
                                         <p class="text-left pl-2" id="memo">{{quotation.memo}}</p>
                                     </b-form-group>
                                 </b-col>
@@ -211,7 +211,7 @@
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="削除日時"
-                                        label-for="updatedAt">
+                                        label-for="updatedAt" label-align="right">
                                         <p class="text-left pl-2" id="updatedAt">{{formatDateTime(quotation.updatedAt)}}
                                         </p>
                                     </b-form-group>

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -60,14 +60,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="会社名"
-                                        label-for="companyName">
+                                        label-for="companyName" label-align="right">
                                         <b-form-input v-model="setting.companyName" id="companyName" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="代表者名"
-                                        label-for="representative">
+                                        label-for="representative" label-align="right">
                                         <b-form-input v-model="setting.representative" id="representative" size="sm">
                                         </b-form-input>
                                     </b-form-group>
@@ -76,14 +76,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="郵便番号"
-                                        label-for="postNumber">
+                                        label-for="postNumber" label-align="right">
                                         <b-form-input v-model="setting.postNumber" id="postNumber" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="住所"
-                                        label-for="address">
+                                        label-for="address" label-align="right">
                                         <b-form-input v-model="setting.address" id="address" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -91,14 +91,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="電話番号"
-                                        label-for="telNumber">
+                                        label-for="telNumber" label-align="right">
                                         <b-form-input v-model="setting.telNumber" id="telNumber" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="FAX番号"
-                                        label-for="faxNumber">
+                                        label-for="faxNumber" label-align="right">
                                         <b-form-input v-model="setting.faxNumber" id="faxNumber" size="sm">
                                         </b-form-input>
                                     </b-form-group>
@@ -107,14 +107,14 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ホームページURL"
-                                        label-for="url">
+                                        label-for="url" label-align="right">
                                         <b-form-input v-model="setting.url" id="url" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="email"
-                                        label-for="email">
+                                        label-for="email" label-align="right">
                                         <b-form-input v-model="setting.email" id="email" size="sm">
                                         </b-form-input>
                                     </b-form-group>

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -97,7 +97,7 @@
                             <b-row>
                                 <b-col>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="単位名"
-                                        label-for="unitName">
+                                        label-for="unitName" label-align="right">
                                         <b-form-input v-model="unit.unitName" id="unitName" size="sm">
                                         </b-form-input>
                                     </b-form-group>

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -104,13 +104,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ユーザー名"
-                                        label-for="name">
+                                        label-for="name" label-align="right">
                                         <b-form-input v-model="user.name" id="name" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="パスワード"
-                                        label-for="password">
+                                        label-for="password" label-align="right">
                                         <b-form-input v-model="user.password" id="password" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -118,13 +118,13 @@
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="グループ"
-                                        label-for="group">
+                                        label-for="group" label-align="right">
                                         <b-form-input v-model="user.group" id="group" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="権限"
-                                        label-for="role">
+                                        label-for="role" label-align="right">
                                         <b-form-select v-model="user.role" size="sm" :options="[
                                         {  value: 'admin', text: 'admin' },
                                         {  value: 'user', text: 'user' },


### PR DESCRIPTION
関連Issue：新規・更新画面まとめ #588

新規・更新画面の入力欄ラベルを全て右揃えに変更した。