### PR TITLE
虫眼鏡ラベルを「検索」に変更＋プレースホルダー適用

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -57,8 +57,8 @@
                             <b-row>
                                 <b-col sm>
                                     <b-row>
-                                        <b-col cols="2">
-                                            <label><i class="fas fa-search"></i></label>
+                                        <b-col cols="2" class="text-left mt-1">
+                                            検索
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchCustomerWord" id="searchCustomerWord"

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -116,8 +116,8 @@
                             <b-row>
                                 <b-col sm>
                                     <b-row>
-                                        <b-col cols="2">
-                                            <label><i class="fas fa-search"></i></label>
+                                        <b-col cols="2" class="text-left mt-1">
+                                            検索
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm">

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -120,7 +120,8 @@
                                             検索
                                         </b-col>
                                         <b-col>
-                                            <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm">
+                                            <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm"
+                                                placeholder="顧客名or日付">
                                             </b-form-input>
                                         </b-col>
                                     </b-row>

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -74,8 +74,8 @@
                             <b-row>
                                 <b-col sm>
                                     <b-row>
-                                        <b-col cols="2">
-                                            <label><i class="fas fa-search"></i></label>
+                                        <b-col cols="2" class="text-left mt-1">
+                                            検索
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm">

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -78,7 +78,8 @@
                                             検索
                                         </b-col>
                                         <b-col>
-                                            <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm">
+                                            <b-form-input v-model="searchInvoiceWord" id="searchInvoiceWord" size="sm"
+                                                placeholder="顧客名or日付">
                                             </b-form-input>
                                         </b-col>
                                     </b-row>

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -86,8 +86,8 @@
                             <b-row>
                                 <b-col sm>
                                     <b-row>
-                                        <b-col cols="2">
-                                            <label><i class="fas fa-search"></i></label>
+                                        <b-col cols="2" class="text-left mt-1">
+                                            検索
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchItemWord" id="searchItemWord" size="sm">

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -86,8 +86,8 @@
                             <b-row>
                                 <b-col sm>
                                     <b-row>
-                                        <b-col cols="2">
-                                            <label><i class="fas fa-search"></i></label>
+                                        <b-col cols="2" class="text-left mt-1">
+                                            検索
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchQuotationWord" id="searchQuotationWord"

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -91,7 +91,7 @@
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchQuotationWord" id="searchQuotationWord"
-                                                size="sm">
+                                                size="sm" placeholder="顧客名or日付">
                                             </b-form-input>
                                         </b-col>
                                     </b-row>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -74,8 +74,8 @@
                             <b-row>
                                 <b-col sm>
                                     <b-row>
-                                        <b-col cols="2">
-                                            <label><i class="fas fa-search"></i></label>
+                                        <b-col cols="2" class="text-left mt-1">
+                                            検索
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchQuotationWord" id="searchQuotationWord"

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -79,7 +79,7 @@
                                         </b-col>
                                         <b-col>
                                             <b-form-input v-model="searchQuotationWord" id="searchQuotationWord"
-                                                size="sm">
+                                                size="sm" placeholder="顧客名or日付">
                                             </b-form-input>
                                         </b-col>
                                     </b-row>


### PR DESCRIPTION
関連Issue：請求・見積ページ一覧。虫眼鏡マークはやっぱり「検索」に戻す #655