### PR TITLE
商品一覧の単価・原価単価にカンマが付くように修正

### DIFF
--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -125,6 +125,12 @@
                           {  key: 'baseCost', label: '原価単価' },
                           {  key: 'memo', label: 'メモ' },
                         ]" :tbody-tr-class="rowClass">
+                                <template v-slot:cell(basePrice)="data">
+                                    {{ data.item.basePrice|nf }}
+                                </template>
+                                <template v-slot:cell(baseCost)="data">
+                                    {{ data.item.baseCost|nf }}
+                                </template>
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">
                                         <b-button variant="primary" @click="selectItem(data.item);"><i
@@ -364,6 +370,11 @@
         </div>
 
         <script>
+            Vue.filter('nf', function (val) {
+                if (isNaN(val)) return null
+                return val.toLocaleString();
+            });
+
             Vue.component('v-select', VueSelect.VueSelect);
             const router = new VueRouter({
             })


### PR DESCRIPTION
関連Issue：商品一覧画面。単価の項目にカンマを付ける #644

単価・原価単価にカンマが付くようにした