### PR TITLE
商品一覧の表示項目「単位」「メモ」の削除

### DIFF
--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -120,10 +120,8 @@
                           {  key: 'itemCode', label: '商品コード' },
                           {  key: 'category', label: 'カテゴリ' },
                           {  key: 'maker', label: 'メーカー' },
-                          {  key: 'unit', label: '単位' },
                           {  key: 'basePrice', label: '単価' },
                           {  key: 'baseCost', label: '原価単価' },
-                          {  key: 'memo', label: 'メモ' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">


### PR DESCRIPTION
関連Issue：商品一覧画面。単位・メモの項目は表示しない #645