### PR TITLE
商品が全件表示できないバグを修正

### DIFF
--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -363,7 +363,8 @@
 
         <script>
             Vue.filter('nf', function (val) {
-                if (isNaN(val)) return null
+                if (isNaN(val)) return null;
+                if (val === null) return;
                 return val.toLocaleString();
             });
 
@@ -589,7 +590,7 @@
                     this.getCategories();
                     this.getMakers();
                     document.querySelector('title').textContent = '商品管理';
-                    if(this.pageName=='show' || this.pageName=='store'){
+                    if (this.pageName == 'show' || this.pageName == 'store') {
                         this.getFileList(this.item.itemCode);
                     }
                 },


### PR DESCRIPTION
関連Issue：商品ページの検索(フィルター)機能。カテゴリ・メーカーを空白にしても全件表示できない。 #692

原因はカンマを付ける関数がnullを返さない事が原因だった。