### PR TITLE
「適用」ボタンを「保存」に変更＋保存ポッパーの廃止

### DIFF
--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -114,9 +114,7 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="modalShow(category,'upsertModal');"
-                            v-b-tooltip.hover.top="'適用'">
-                            適用
+                        <b-button pill variant="primary" @click="modalShow(category,'upsertModal');">保存
                         </b-button>
                         <b-button pill size="lg" variant="primary" @click="alert('印刷しました。')"
                             v-b-tooltip.hover.top="'印刷'">

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -299,7 +299,7 @@
                         <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="apply();" v-b-tooltip.hover.top="'適用'">適用</b-button>
+                        <b-button pill variant="primary" @click="apply();">保存</b-button>
                         <b-button pill size="lg" variant="primary" @click="pdfOut" v-b-tooltip.hover.top="'印刷'"><i
                                 class="fas fa-print"></i>
                         </b-button>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -168,7 +168,8 @@
                                     {{amountCalculation(data.item)|nf}}
                                 </template>
                                 <template v-slot:cell(numberOfAttachments)="data">
-                                    <b-badge pill variant="warning" v-if="data.item.numberOfAttachments > 0">{{data.item.numberOfAttachments}}</b-badge>
+                                    <b-badge pill variant="warning" v-if="data.item.numberOfAttachments > 0">
+                                        {{data.item.numberOfAttachments}}</b-badge>
                                 </template>
 
                             </b-table>
@@ -419,7 +420,7 @@
                             </template>
 
                             <template v-slot:cell(isDelete)="data">
-                                <b-form-checkbox  v-model="data.item.isDelete" ></b-form-checkbox>
+                                <b-form-checkbox v-model="data.item.isDelete"></b-form-checkbox>
                             </template>
 
                         </b-table>
@@ -553,8 +554,7 @@
                         <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="primary" @click="bulkUpsert(invoice);showConfirmModal();"
-                            v-b-tooltip.hover.top="'保存'">保存
+                        <b-button pill variant="primary" @click="bulkUpsert(invoice);showConfirmModal();">保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(invoice,'copyModal');" v-b-tooltip.hover.top="'複製'"><i
@@ -724,7 +724,7 @@
                         self = this;
                         self.invoices.push({
                             isInsert: true,
-                            invoice_items: [{isDelete:false},{isDelete:false},{isDelete:false},{isDelete:false},{isDelete:false}],
+                            invoice_items: [{ isDelete: false }, { isDelete: false }, { isDelete: false }, { isDelete: false }, { isDelete: false }],
                         });
                         self.invoice = self.invoices.slice(-1)[0];
                         Vue.set(self.invoice, 'isTaxExp', true);
@@ -756,20 +756,20 @@
                                 }
                             });
                     },
-//                    deleteInvoiceItem: async function (item) {
-//                        self = this;
-//                        if (item.id) {
-//                            await axios.delete("/invoice_item/" + item.id)
-//                                .then(function (response) {
-//                                    console.log(response);
-//                                    self.getInvoice(self.invoice);
-//                                });
-//                        }
-//                        else {
-//                            let indexNum = this.invoice.invoice_items.indexOf(item);
-//                            this.invoice.invoice_items.splice(indexNum, 1);
-//                        }
-//                    },
+                    //                    deleteInvoiceItem: async function (item) {
+                    //                        self = this;
+                    //                        if (item.id) {
+                    //                            await axios.delete("/invoice_item/" + item.id)
+                    //                                .then(function (response) {
+                    //                                    console.log(response);
+                    //                                    self.getInvoice(self.invoice);
+                    //                                });
+                    //                        }
+                    //                        else {
+                    //                            let indexNum = this.invoice.invoice_items.indexOf(item);
+                    //                            this.invoice.invoice_items.splice(indexNum, 1);
+                    //                        }
+                    //                    },
                     addRowInvoiceItem: function () {
                         if (this.invoice.length === 0) {
                             alert('請求書を選択してください');
@@ -969,14 +969,14 @@
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
                     amountCalculation(invoice) {
-                        if(!invoice.invoice_items.length) return 0;
+                        if (!invoice.invoice_items.length) return 0;
                         let amount = invoice.invoice_items.map(item => item.count * item.price).reduce((a, b) => a + b);
                         if (invoice.isTaxExp === true) return Math.floor(amount * 1.1);
                         return amount;
                     },
                     //---- upload funcrions --
                     async getFileListDZ() {
-                        this.invoice.numberOfAttachments =  await this.getFileList(this.invoice.applyNumber);
+                        this.invoice.numberOfAttachments = await this.getFileList(this.invoice.applyNumber);
                     },
                     getFileList: async function (fid) {
                         self = this;
@@ -1037,7 +1037,7 @@
                     this.getMakers();
                     this.getSetting();
                     document.querySelector('title').textContent = '請求書管理';
-                    if(this.pageName == 'show'){
+                    if (this.pageName == 'show') {
                         //this.getFileList(self.invoice.applyNumber);
                         this.getFileListDZ();
 
@@ -1050,7 +1050,7 @@
                         this.routeTo = 'show';
                         initDropzone();
                     }
-                    if (this.pageName == 'show' && this.routeFrom=='' && this.routeTo == '' ){ 
+                    if (this.pageName == 'show' && this.routeFrom == '' && this.routeTo == '') {
                         this.routeFrom = 'show';
                         this.routeTo = 'show';
                         initDropzone();
@@ -1150,23 +1150,23 @@
                     });
                 }
             }
-            function initDropzone(){
-                        Dropzone.autoDiscover = false;
-                        console.log("init dropzone");
-                        destroyDrop();
-                        dropz = new Dropzone("form#dropz",{
-                            dictDefaultMessage: '<h2>+</h2>',
-                            parallelUploads: 2,
-                            init: function () {
-                                this.on("complete", file => {
-                                    console.log("complete A file has been added");
-                                    if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
-                                        this.removeFile(file);
-                                        app.getFileListDZ();
-                                    }
-                                });
+            function initDropzone() {
+                Dropzone.autoDiscover = false;
+                console.log("init dropzone");
+                destroyDrop();
+                dropz = new Dropzone("form#dropz", {
+                    dictDefaultMessage: '<h2>+</h2>',
+                    parallelUploads: 2,
+                    init: function () {
+                        this.on("complete", file => {
+                            console.log("complete A file has been added");
+                            if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
+                                this.removeFile(file);
+                                app.getFileListDZ();
                             }
                         });
+                    }
+                });
             }
             // end アップロード機能
         </script>

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -130,7 +130,8 @@
                                     {{ data.item.baseCost|nf }}
                                 </template>
                                 <template v-slot:cell(numberOfAttachments)="data">
-                                    <b-badge pill variant="warning" v-if="data.item.numberOfAttachments > 0">{{data.item.numberOfAttachments}}</b-badge>
+                                    <b-badge pill variant="warning" v-if="data.item.numberOfAttachments > 0">
+                                        {{data.item.numberOfAttachments}}</b-badge>
                                 </template>
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">
@@ -341,8 +342,7 @@
                         <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="modalShow(item,'upsertModal');"
-                            v-b-tooltip.hover.top="'適用'">適用
+                        <b-button pill variant="primary" @click="modalShow(item,'upsertModal');">保存
                         </b-button>
                         <b-button pill size="lg" variant="primary" @click="alert('印刷しました。')"
                             v-b-tooltip.hover.top="'印刷'">

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -111,8 +111,7 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="modalShow(maker,'upsertModal');"
-                            v-b-tooltip.hover.top="'適用'">適用
+                        <b-button pill variant="primary" @click="modalShow(maker,'upsertModal');">保存
                         </b-button>
                         <b-button pill size="lg" variant="primary" @click="alert('印刷しました。')"
                             v-b-tooltip.hover.top="'印刷'">

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -171,8 +171,7 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="modalShow(memo,'upsertModal');"
-                            v-b-tooltip.hover.top="'適用'">適用
+                        <b-button pill variant="primary" @click="modalShow(memo,'upsertModal');">保存
                         </b-button>
                         <b-button pill size="lg" variant="primary" @click="alert('印刷しました。')"
                             v-b-tooltip.hover.top="'印刷'">

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -176,7 +176,8 @@
                                     {{amountCalculation(data.item)|nf}}
                                 </template>
                                 <template v-slot:cell(numberOfAttachments)="data">
-                                    <b-badge pill variant="warning" v-if="data.item.numberOfAttachments > 0">{{data.item.numberOfAttachments}}</b-badge>
+                                    <b-badge pill variant="warning" v-if="data.item.numberOfAttachments > 0">
+                                        {{data.item.numberOfAttachments}}</b-badge>
                                 </template>
                             </b-table>
                         </b-card>
@@ -419,7 +420,7 @@
                             </template>
 
                             <template v-slot:cell(isDelete)="data">
-                                <b-form-checkbox  v-model="data.item.isDelete" ></b-form-checkbox>
+                                <b-form-checkbox v-model="data.item.isDelete"></b-form-checkbox>
                             </template>
 
                         </b-table>
@@ -542,9 +543,7 @@
                         <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="primary" @click="bulkUpsert(quotation);showConfirmModal();"
-                            v-b-tooltip.hover.top="'保存'">
-                            保存
+                        <b-button pill variant="primary" @click="bulkUpsert(quotation);showConfirmModal();">保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(quotation,'copyModal');" v-b-tooltip.hover.top="'複製'"><i
@@ -708,7 +707,7 @@
                         self = this;
                         self.quotations.push({
                             isInsert: true,
-                            quotation_items: [{isDelete:false},{isDelete:false},{isDelete:false},{isDelete:false},{isDelete:false}],
+                            quotation_items: [{ isDelete: false }, { isDelete: false }, { isDelete: false }, { isDelete: false }, { isDelete: false }],
                         });
                         self.quotation = self.quotations.slice(-1)[0];
                         Vue.set(self.quotation, 'isTaxExp', true);
@@ -885,7 +884,7 @@
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
                     amountCalculation(quotation) {
-                        if(!quotation.quotation_items.length) return 0;
+                        if (!quotation.quotation_items.length) return 0;
                         let amount = quotation.quotation_items.map(item => item.count * item.price).reduce((a, b) => a + b);
                         if (quotation.isTaxExp === true) return Math.floor(amount * 1.1);
                         return amount;
@@ -991,7 +990,7 @@
                     this.getMakers();
                     this.getSetting();
                     document.querySelector('title').textContent = '見積書管理';
-                    if(this.pageName == 'show'){
+                    if (this.pageName == 'show') {
                         this.getFileListDZ();
                     }
                 },
@@ -1101,23 +1100,23 @@
                     });
                 }
             }
-            function initDropzone(){
-                        Dropzone.autoDiscover = false;
-                        console.log("init dropzone");
-                        destroyDrop();
-                        dropz = new Dropzone("#dropz",{
-                            dictDefaultMessage: '<h2>+</h2>',
-                            parallelUploads: 2,
-                            init: function () {
-                                this.on("complete", file => {
-                                    console.log("complete A file has been added");
-                                    if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
-                                        this.removeFile(file);
-                                        app.getFileListDZ();
-                                    }
-                                });
+            function initDropzone() {
+                Dropzone.autoDiscover = false;
+                console.log("init dropzone");
+                destroyDrop();
+                dropz = new Dropzone("#dropz", {
+                    dictDefaultMessage: '<h2>+</h2>',
+                    parallelUploads: 2,
+                    init: function () {
+                        this.on("complete", file => {
+                            console.log("complete A file has been added");
+                            if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
+                                this.removeFile(file);
+                                app.getFileListDZ();
                             }
                         });
+                    }
+                });
             }
             // end アップロード機能
         </script>

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -235,7 +235,7 @@
                         </b-button>
                     </b-col>
                     <b-col cols="4" class="text-right">
-                        <b-button variant="primary" class="mr-3" @click="bulkUpsert(setting)">適用</b-button>
+                        <b-button variant="primary" class="mr-3" @click="bulkUpsert(setting)">保存</b-button>
                     </b-col>
                 </b-row>
             </b-card>

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -125,8 +125,7 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="modalShow(unit,'upsertModal');"
-                            v-b-tooltip.hover.top="'適用'">適用
+                        <b-button pill variant="primary" @click="modalShow(unit,'upsertModal');">保存
                         </b-button>
                         <b-button pill size="lg" variant="primary" @click="alert('印刷しました。')"
                             v-b-tooltip.hover.top="'印刷'">

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -156,8 +156,7 @@
                         </router-link>
                     </b-col>
                     <b-col class="text-right">
-                        <b-button pill variant="primary" @click="modalShow(user,'upsertModal');"
-                            v-b-tooltip.hover.top="'適用'">適用
+                        <b-button pill variant="primary" @click="modalShow(user,'upsertModal');">保存
                         </b-button>
                         <b-button pill size="lg" variant="primary" @click="alert('印刷しました。')"
                             v-b-tooltip.hover.top="'印刷'">


### PR DESCRIPTION
関連Issue：全ページ「適用」ボタンは「保存」に変更する。 #724
新規・更新画面の「保存」ポッパーはいらない #685

- 全ページの新規・更新画面「適用」ボタンを「保存」に変更
- 保存ボタンホバー時の「保存」ポッパーの廃止