### PR TITLE
商品一覧画面のカテゴリ・メーカー検索欄にプレースホルダを適用

### DIFF
--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -87,12 +87,22 @@
                                         label-for="createdAt">
                                         <b-form-select v-model="searchItemSelectCategory" :options="categories"
                                             size="sm">
+                                            <template #first>
+                                                <b-form-select-option value='' disabled>カテゴリー
+                                                </b-form-select-option>
+                                            </template>
+                                        </b-form-select>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="6" label-cols-lg="6" label-size="sm" label="メーカー"
                                         label-for="createdAt">
                                         <b-form-select v-model="searchItemSelectMaker" :options="makers" size="sm">
+                                            <template #first>
+                                                <b-form-select-option value='' disabled>メーカー
+                                                </b-form-select-option>
+                                            </template>
+                                        </b-form-select>
                                     </b-form-group>
                                 </b-col>
                                 <b-col sm>


### PR DESCRIPTION
関連Issue：商品一覧のカテゴリ・メーカー検索チェックボックスにプレースホルダー #747

配置レイアウト案が届いたら続きを修正。