### PR TITLE
商品のみポップアップ対応 Add 38 tingle

### DIFF
--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -3,6 +3,11 @@
         <!-- or point to a specific vue-select release -->
         <script src="https://unpkg.com/vue-select@3.0.0"></script>
         <link rel="stylesheet" href="https://unpkg.com/vue-select@3.0.0/dist/vue-select.css">
+        <!-- viewerとして使用-->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.min.js" integrity="sha512-2B9/byNV1KKRm5nQ2RLViPFD6U4dUjDGwuW1GU+ImJh8YinPU9Zlq1GzdTMO+G2ROrB5o1qasJBy1ttYz0wCug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.css" integrity="sha512-k6op6U+6fzScsVhxntLBg+Ob/Gv64fjNfjuAcNtbngRoi1LKf+aicRaEs3zeTrRuoIkOjGwLf9FR5BR7B3NItw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        
+
         <style>
             .card-header {
                 background-color: #ccecf1;
@@ -42,6 +47,27 @@
                 display: flex;
                 flex-wrap: wrap;
             }
+            /* tingle で使用するCSS */
+            .tingle-modal {
+                background: rgba(0, 0, 0, .5);
+            }
+            .tingle-modal-box__content {
+                padding: 0;
+            }
+            .iframe-wrapper {
+                position: relative;
+                padding-bottom: 150%;
+                height: 0;
+                overflow: hidden;
+            }
+            .iframe-wrapper iframe {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+            }
+
         </style>
 
         <div id="app" v-cloak>
@@ -292,9 +318,7 @@
                                                     <input type="checkbox" v-model="f.isSelect" size="sm">
                                                 </b-td>
                                                 <b-td width="15%">
-                                                    <div @click="selectImgUrl=f.url">
-                                                        <b-img :src="f.urlThumb" width="90" fluid></b-img>
-                                                    </div>
+                                                    <b-img :src="f.urlThumb" @click="openViewer(f)" width="90" fluid></b-img>
                                                 </b-td>
                                                 <b-td class="ml-5">{{f.filename}}</b-td>
                                             </b-tr>
@@ -305,7 +329,7 @@
                                     <div class="file-card ">
                                         <template v-for="f in dicFiles">
                                             <b-card border-variant="light">
-                                                <b-img :src="'../'+f.thumbPath" width="90" fluid></b-img>
+                                                <b-img :src="'../'+f.thumbPath" @click="openViewer(f)" width="90" fluid></b-img>
                                                 <input type="checkbox" v-model="f.isSelect" class="image-in-check">
                                             </b-card>
                                         </template>
@@ -601,8 +625,20 @@
                         }
                         this.clearFileList();
                         router.push({ path: "?page=index" });
+                    },
+                    openViewer: function(f){
+                        //this.modal.setFooterContent(f.filename);
+                        content = ''
+                        if(f.type == 'pdf'){    
+                            content = "<div class='iframe-wrapper' ><iframe src="+f.url+" frameborder='0'></iframe></div>"
+                        }else if(f.type == 'csv'){    
+                            content = "このファイルはViwerでは開けません";
+                        }else{
+                            content = "<img src="+f.url+" width='100%'>"
+                        }                  
+                        this.modal.setContent(content);
+                        this.modal.open();
                     }
-
                 },
                 mounted: function () {
                     this.item = JSON.parse(localStorage.getItem('item'));
@@ -614,6 +650,13 @@
                     if (this.pageName == 'show' || this.pageName == 'store') {
                         this.getFileListDZ();
                     }
+                    this.modal = new tingle.modal({
+                        footer: false,
+                        stickyFooter: false,
+                        closeMethods: ['overlay', 'button', 'escape'],
+                        closeLabel: "Close",
+                    });
+
                 },
                 updated: function () {
                     self = this;

--- a/app/templates/uptest.html
+++ b/app/templates/uptest.html
@@ -52,6 +52,10 @@
 <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/dropzone@5/dist/min/dropzone.min.css" type="text/css" />
 
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.min.js" integrity="sha512-2B9/byNV1KKRm5nQ2RLViPFD6U4dUjDGwuW1GU+ImJh8YinPU9Zlq1GzdTMO+G2ROrB5o1qasJBy1ttYz0wCug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.css" integrity="sha512-k6op6U+6fzScsVhxntLBg+Ob/Gv64fjNfjuAcNtbngRoi1LKf+aicRaEs3zeTrRuoIkOjGwLf9FR5BR7B3NItw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
 <style>
     .image-box {
         position: relative;
@@ -194,12 +198,12 @@
             :items= 'dicFiles'
         > 
             <template v-slot:cell(image)="data">
-                <b-img :src="data.item.thumbPath" width="90"></b-img>
+                <b-img :src="data.item.thumbPath" width="90" @click="showImage(data.item)"></b-img>
             </template>
         </b-table>
     </div>
 
-
+    <b-button @click="modal.open()">modal open </b-button>
 
 
     <br /><br />
@@ -225,7 +229,8 @@
                 file: '',
                 fileId:''
             },
-            url: ''
+            url: '',
+            //modal: null
         },
         methods: {
             getFileList: async function (fid) {
@@ -286,13 +291,98 @@
             },
             formUpload: function(){
                 form = document.getElementById('form-upload').submit()
+            },
+            showImage: function(f){
+                this.modal.setContent("<img src="+f.url+" width='320'>");
+                this.modal.open();
             }
 
         },
         mounted: function () {
             this.getFileList('001');
+                // instanciate new modal
+            this.modal = new tingle.modal({
+                footer: true,
+                stickyFooter: false,
+                closeMethods: ['overlay', 'button', 'escape'],
+                closeLabel: "Close",
+                //cssClass: ['custom-class-1', 'custom-class-2'],
+                onOpen: function() {
+                        console.log('modal open');
+                        //this.setContent('<h1>here\'s some content</h1>');
+                    },
+                    onClose: function() {
+                        console.log('modal closed');
+                    },
+                    beforeClose: function() {
+                        // here's goes some logic
+                        // e.g. save content before closing the modal
+                        return true; // close the modal
+                        return false; // nothing happens
+                    },
+            });
+            //this.modal = modal;
+            // set content
+            //modal.setContent('<h1>here\'s some content</h1>');
+
+            // add a button
+            //modal.addFooterBtn('Button label', 'tingle-btn tingle-btn--primary', function() {
+                // here goes some logic
+            //    modal.close();
+            //});
+
+            // add another button
+            //modal.addFooterBtn('Dangerous action !', 'tingle-btn tingle-btn--danger', function() {
+                // here goes some logic
+            //    modal.close();
+            //});            
+
         }
     });
+
+/*
+    // instanciate new modal
+    var modal = new tingle.modal({
+        footer: true,
+        stickyFooter: false,
+        closeMethods: ['overlay', 'button', 'escape'],
+        closeLabel: "Close",
+        cssClass: ['custom-class-1', 'custom-class-2'],
+        onOpen: function() {
+            console.log('modal open');
+        },
+        onClose: function() {
+            console.log('modal closed');
+        },
+        beforeClose: function() {
+            // here's goes some logic
+            // e.g. save content before closing the modal
+            return true; // close the modal
+            return false; // nothing happens
+        }
+    });
+
+    // set content
+    modal.setContent('<h1>here\'s some content</h1>');
+
+    // add a button
+    modal.addFooterBtn('Button label', 'tingle-btn tingle-btn--primary', function() {
+        // here goes some logic
+        modal.close();
+    });
+
+    // add another button
+    modal.addFooterBtn('Dangerous action !', 'tingle-btn tingle-btn--danger', function() {
+        // here goes some logic
+        modal.close();
+    });
+
+    // open modal
+    //modal.open();
+
+    // close modal
+    //modal.close();
+*/
 </script>
 
 </html>

--- a/app/templates/uptest.html
+++ b/app/templates/uptest.html
@@ -86,6 +86,29 @@
     .custom-file-label::after {
         content: '+';
     }
+
+    .tingle-modal {
+        background: rgba(0, 0, 0, .5);
+    }
+    .tingle-modal-box__content {
+        padding: 0;
+    }
+    .iframe-wrapper {
+        position: relative;
+        padding-bottom: 150%;
+        height: 0;
+        overflow: hidden;
+    }
+
+    .iframe-wrapper iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+
+
 </style>
 
 
@@ -198,7 +221,7 @@
             :items= 'dicFiles'
         > 
             <template v-slot:cell(image)="data">
-                <b-img :src="data.item.thumbPath" width="90" @click="showImage(data.item)"></b-img>
+                <b-img :src="data.item.thumbPath" width="90" @click="openViwer(data.item)"></b-img>
             </template>
         </b-table>
     </div>
@@ -292,8 +315,18 @@
             formUpload: function(){
                 form = document.getElementById('form-upload').submit()
             },
-            showImage: function(f){
-                this.modal.setContent("<img src="+f.url+" width='320'>");
+            openViwer: function(f){
+                this.modal.setFooterContent(f.filename);
+                content = ''
+                if(f.type == 'pdf'){    
+                    content = "<div class='iframe-wrapper' ><iframe src="+f.url+" frameborder='0'></iframe></div>"
+                }else if(f.type == 'csv'){    
+                    content = "<h3>このファイルはViwerでは開けません</h3>";
+                }else{
+                    content = "<img src="+f.url+" width='100%'>"
+                }
+            
+                this.modal.setContent(content);
                 this.modal.open();
             }
 
@@ -308,18 +341,18 @@
                 closeLabel: "Close",
                 //cssClass: ['custom-class-1', 'custom-class-2'],
                 onOpen: function() {
-                        console.log('modal open');
+                        //console.log('modal open');
                         //this.setContent('<h1>here\'s some content</h1>');
                     },
-                    onClose: function() {
-                        console.log('modal closed');
-                    },
-                    beforeClose: function() {
-                        // here's goes some logic
-                        // e.g. save content before closing the modal
-                        return true; // close the modal
-                        return false; // nothing happens
-                    },
+                onClose: function() {
+                    //console.log('modal closed');
+                },
+                beforeClose: function() {
+                    // here's goes some logic
+                    // e.g. save content before closing the modal
+                    return true; // close the modal
+                    return false; // nothing happens
+                },
             });
             //this.modal = modal;
             // set content


### PR DESCRIPTION
とりあえず商品のみポップアップビュワーを実装してみた。
これでよければ、全摘要する。


考察点・備忘
・tingleライブラリを使用
・ポップアップ対象ファイルは現時点では、jpg、pdfのみ
・MIME TYPで判断していない。拡張子で判断している。
・将来的にはMIMEで判定する必要があると思われる。
・なぜなら、画像や動画、音声などに対応する場合、拡張子では種類が多すぎて対応できない。
・MIMEで判定するならしかるべきViwerを立ち上げるようにすることが可能。
・その場合はサーバーとの連携が必要。FLASK側でMIMEタイプを判定し、コンテントヘッダーにセットする形がとれる。
