### PR TITLE
一覧画面の「添付」ヘッダーを削除

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -152,7 +152,7 @@
                           {  key: 'customerName', label: '顧客名' },
                           {  key: 'title', label: '件名' },
                           {  key: 'totalAmount', label: '合計金額', thClass: 'text-center', tdClass: 'text-right' },
-                          {  key: 'numberOfAttachments', label: '添付' },
+                          {  key: 'numberOfAttachments', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -124,7 +124,7 @@
                           {  key: 'maker', label: 'メーカー' },
                           {  key: 'basePrice', label: '単価', thClass: 'text-center', tdClass: 'text-right' },
                           {  key: 'baseCost', label: '原価単価', thClass: 'text-center', tdClass: 'text-right' },
-                          {  key: 'numberOfAttachments', label: '添付' },
+                          {  key: 'numberOfAttachments', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(basePrice)="data">
                                     {{ data.item.basePrice|nf }}

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -160,7 +160,7 @@
                           {  key: 'customerName', label: '顧客名' },
                           {  key: 'title', label: '件名' },
                           {  key: 'totalAmount', label: '合計金額', thClass: 'text-center', tdClass: 'text-right' },
-                          {  key: 'numberOfAttachments', label: '添付' },
+                          {  key: 'numberOfAttachments', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">
                                     <router-link to="?page=show">


### PR DESCRIPTION
関連Issue：商品一覧の添付項目。テーブルヘッダーの添付の文字は非表示 #746