### PR TITLE
２行問題解消法。見積書にも反映。請求ページ微修正。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -322,6 +322,7 @@
                             <template v-slot:cell(itemName)="data">
                                 <textarea v-model="data.item.itemName" class="form-control form-control-sm itemNameArea"
                                     rows="1" @dblclick="showModalItems(); selectInvoiceItem(data.item);"
+                                    v-on:keydown.enter="selectInvoiceItem(data.item);Vue.set(self.invoiceItem,'itemId',null);"
                                     :style="heightItemName(data.item.itemName)">
                                 </textarea>
 
@@ -885,12 +886,6 @@
                         Vue.set(self.invoiceItem, 'cost', record.baseCost);
                         this.$refs['items-modal'].hide()
                     },
-                    // 商品名入力→Enter
-                    //onKeyDownItem(indexNum) {
-                    //    Vue.set(self.invoiceItem, 'itemId', null);
-                    //    console.log(indexNum);
-                    //    $('#invoice_items_table').children('tbody').children('tr').eq(indexNum).find('.itemNameArea').attr("rows", "2");
-                    //},
                     // 商品名モーダル表示 モーダルのダブり表示防止
                     showModalItems() {
                         this.$refs['items-modal'].show()
@@ -1024,16 +1019,6 @@
                         this.clearFileList();
                         router.push({ path: "?page=index" });
                     },
-//                    checkRow() {
-//                        setTimeout(() => {
-//                            this.invoice.invoice_items.forEach(function (element, index) {
-//                                if (element.itemName.indexOf('\n') != -1) {
-//                                    console.log(index);
-//                                    $('#invoice_items_table').children('tbody').children('tr').eq(index).find('.itemNameArea').attr("rows", "2");
-//                                }
-//                            });
-//                        }, 1);
-//                    },
                     openViewer: function (f) {
                         //this.modal.setFooterContent(f.filename);
                         content = ''
@@ -1047,11 +1032,12 @@
                         this.modal.setContent(content);
                         this.modal.open();
                     },
-                    heightItemName: function(data){
-                        if (!data) return "height: 30px"
-                        row = data.indexOf('\n') != -1 ? 2 :  1
-                        return "height: "+ 30*row +"px"
-                    }
+                    heightItemName: function (data) {
+                        if (!data) return "height: 30px";
+                        row = data.indexOf('\n') != -1 ? 2 : 1;
+                        interval = row > 1 ? 0 : 4;
+                        return "height: " + (26 * row + interval) + "px";
+                    },
 
                 },
                 mounted: function () {

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -3,8 +3,12 @@
         <script src="https://printjs-4de6.kxcdn.com/print.min.js"></script>
         <link href="https://printjs-4de6.kxcdn.com/print.min.css" rel="stylesheet">
         <!-- viewerとして使用-->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.min.js" integrity="sha512-2B9/byNV1KKRm5nQ2RLViPFD6U4dUjDGwuW1GU+ImJh8YinPU9Zlq1GzdTMO+G2ROrB5o1qasJBy1ttYz0wCug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.css" integrity="sha512-k6op6U+6fzScsVhxntLBg+Ob/Gv64fjNfjuAcNtbngRoi1LKf+aicRaEs3zeTrRuoIkOjGwLf9FR5BR7B3NItw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.min.js"
+            integrity="sha512-2B9/byNV1KKRm5nQ2RLViPFD6U4dUjDGwuW1GU+ImJh8YinPU9Zlq1GzdTMO+G2ROrB5o1qasJBy1ttYz0wCug=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tingle/0.16.0/tingle.css"
+            integrity="sha512-k6op6U+6fzScsVhxntLBg+Ob/Gv64fjNfjuAcNtbngRoi1LKf+aicRaEs3zeTrRuoIkOjGwLf9FR5BR7B3NItw=="
+            crossorigin="anonymous" referrerpolicy="no-referrer" />
 
         <style>
             .card-header {
@@ -361,7 +365,8 @@
                             <template v-slot:cell(itemName)="data">
                                 <textarea v-model="data.item.itemName" class="form-control form-control-sm itemNameArea"
                                     rows="1" @dblclick="showModalItems(); selectQuotationItem(data.item);"
-                                    v-on:keydown.enter="selectQuotationItem(data.item);onKeyDownItem(data.index);">
+                                    v-on:keydown.enter="selectQuotationItem(data.item);Vue.set(self.quotationItem,'itemId',null);"
+                                    :style="heightItemName(data.item.itemName)">
                                 </textarea>
 
                                 <b-modal size="xl" ref="items-modal" ok-only ok-title="閉じる" hide-header id="item-modal">
@@ -536,7 +541,8 @@
                                     <div class="file-card ">
                                         <template v-for="f in dicFiles">
                                             <b-card border-variant="light">
-                                                <b-img :src="'../'+f.thumbPath" @click="openViewer(f)" width="90" fluid></b-img>
+                                                <b-img :src="'../'+f.thumbPath" @click="openViewer(f)" width="90" fluid>
+                                                </b-img>
                                                 <input type="checkbox" v-model="f.isSelect" class="image-in-check">
                                             </b-card>
                                         </template>
@@ -904,12 +910,6 @@
                         Vue.set(self.quotationItem, 'cost', record.baseCost);
                         this.$refs['items-modal'].hide()
                     },
-                    // 商品名入力→Enter
-                    onKeyDownItem(indexNum) {
-                        Vue.set(self.quotationItem, 'itemId', null);
-                        console.log(indexNum);
-                        $('#quotation_items_table').children('tbody').children('tr').eq(indexNum).find('.itemNameArea').attr("rows", "2");
-                    },
                     // 商品名モーダル表示 モーダルのダブり表示防止
                     showModalItems() {
                         this.$refs['items-modal'].show()
@@ -1013,19 +1013,25 @@
                                 */
                             });
                     },
-                    openViewer: function(f){
+                    openViewer: function (f) {
                         //this.modal.setFooterContent(f.filename);
                         content = ''
-                        if(f.type == 'pdf'){    
-                            content = "<div class='iframe-wrapper' ><iframe src="+f.url+" frameborder='0'></iframe></div>"
-                        }else if(f.type == 'csv'){    
+                        if (f.type == 'pdf') {
+                            content = "<div class='iframe-wrapper' ><iframe src=" + f.url + " frameborder='0'></iframe></div>"
+                        } else if (f.type == 'csv') {
                             content = "このファイルはViwerでは開けません";
-                        }else{
-                            content = "<img src="+f.url+" width='100%'>"
-                        }                  
+                        } else {
+                            content = "<img src=" + f.url + " width='100%'>"
+                        }
                         this.modal.setContent(content);
                         this.modal.open();
-                    }                    
+                    },
+                    heightItemName: function (data) {
+                        if (!data) return "height: 30px";
+                        row = data.indexOf('\n') != -1 ? 2 : 1;
+                        interval = row > 1 ? 0 : 4;
+                        return "height: " + (26 * row + interval) + "px";
+                    },
                 },
                 mounted: function () {
                     this.quotation = JSON.parse(localStorage.getItem('quotation'));


### PR DESCRIPTION
関連Issue：請求・見積ページの明細の商品名欄は更新時に２行じゃないので修正 #687

プルリク761への返答。２行問題解決　Test 761 rows #763
を見積書にも適用してみた。助かった。
Enter時にitemIdをnullにしないといけないので、Enter時のイベントは戻して変更を加えた。