### PR TITLE
「登録」日ラベルを「作成」日に変更

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -198,7 +198,7 @@
                                 <span class="mr-2">請求No:{{invoice.applyNumber}}</span>
                             </b-col>
                             <b-col class="text-right">
-                                <span class="mr-2">登録日:{{formatDate(invoice.createdAt)}}</span>
+                                <span class="mr-2">作成日:{{formatDate(invoice.createdAt)}}</span>
                                 <span class="mr-2">更新日:{{formatDate(invoice.updatedAt)}}</span>
                             </b-col>
                         </b-row>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -204,7 +204,7 @@
                                 <span class="mr-2">見積No:{{quotation.applyNumber}}</span>
                             </b-col>
                             <b-col class="text-right">
-                                <span class="mr-2">登録日:{{formatDate(quotation.createdAt)}}</span>
+                                <span class="mr-2">作成日:{{formatDate(quotation.createdAt)}}</span>
                                 <span class="mr-2">更新日:{{formatDate(quotation.updatedAt)}}</span>
                             </b-col>
                         </b-row>


### PR DESCRIPTION
関連Issue：請求・見積書の「登録日」ラベルを「作成日」に変更 #766

請求と見積のみラベル変更らしい。