### PR TITLE
削除済み一覧ページのフッターのボタンを一部削除

### DIFF
--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -357,30 +357,10 @@
                 <b-row v-else>
                     <b-col class="pc-mode">
                         <b-button href="/dust-select-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
                     </b-col>
                     <b-col class="sm-mode">
                         <b-button href="/dust-select-page">
                             <b-icon icon="chevron-left"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -345,30 +345,10 @@
                 <b-row v-else>
                     <b-col class="pc-mode">
                         <b-button href="/dust-select-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
                     </b-col>
                     <b-col class="sm-mode">
                         <b-button href="/dust-select-page">
                             <b-icon icon="chevron-left"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>


### PR DESCRIPTION
関連Issue：削除済み一覧ページのフッターは「＜」のみ #641