### PR TITLE
設定系ページのフッター文言修正

### DIFF
--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -145,16 +145,16 @@
                 </b-row>
                 <b-row v-else>
                     <b-col class="pc-mode">
-                        <b-button href="/setting-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
+                        <b-button href="/setting-page">会社情報</b-button>
+                        <b-button href="/user-page">ユーザー</b-button>
+                        <b-button href="/category-page">カテゴリ</b-button>
+                        <b-button href="/maker-page">メーカー</b-button>
+                        <b-button href="/unit-page">単位</b-button>
+                        <b-button href="/dust-select-page">削除済み</b-button>
                     </b-col>
                     <b-col class="sm-mode">
-                        <b-button href="/setting-page">
-                            <b-icon icon="chevron-left"></b-icon>
+                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                            <b-icon icon="building"></b-icon>
                         </b-button>
                         <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
@@ -163,7 +163,7 @@
                             <b-icon icon="folder2"></b-icon>
                         </b-button>
                         <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
+                            <b-icon icon="shop"></b-icon>
                         </b-button>
                         <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>

--- a/app/templates/dust_select.html
+++ b/app/templates/dust_select.html
@@ -66,16 +66,16 @@
             <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
                 <b-row>
                     <b-col class="pc-mode">
-                        <b-button href="/setting-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
+                        <b-button href="/setting-page">会社情報</b-button>
+                        <b-button href="/user-page">ユーザー</b-button>
+                        <b-button href="/category-page">カテゴリ</b-button>
+                        <b-button href="/maker-page">メーカー</b-button>
+                        <b-button href="/unit-page">単位</b-button>
+                        <b-button href="/dust-select-page">削除済み</b-button>
                     </b-col>
                     <b-col class="sm-mode">
-                        <b-button href="/setting-page">
-                            <b-icon icon="chevron-left"></b-icon>
+                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                            <b-icon icon="building"></b-icon>
                         </b-button>
                         <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
@@ -84,7 +84,7 @@
                             <b-icon icon="folder2"></b-icon>
                         </b-button>
                         <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
+                            <b-icon icon="shop"></b-icon>
                         </b-button>
                         <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -142,16 +142,16 @@
                 </b-row>
                 <b-row v-else>
                     <b-col class="pc-mode">
-                        <b-button href="/setting-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
+                        <b-button href="/setting-page">会社情報</b-button>
+                        <b-button href="/user-page">ユーザー</b-button>
+                        <b-button href="/category-page">カテゴリ</b-button>
+                        <b-button href="/maker-page">メーカー</b-button>
+                        <b-button href="/unit-page">単位</b-button>
+                        <b-button href="/dust-select-page">削除済み</b-button>
                     </b-col>
                     <b-col class="sm-mode">
-                        <b-button href="/setting-page">
-                            <b-icon icon="chevron-left"></b-icon>
+                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                            <b-icon icon="building"></b-icon>
                         </b-button>
                         <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
@@ -160,7 +160,7 @@
                             <b-icon icon="folder2"></b-icon>
                         </b-button>
                         <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
+                            <b-icon icon="shop"></b-icon>
                         </b-button>
                         <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -219,13 +219,17 @@
             <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
                 <b-row>
                     <b-col class="pc-mode">
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
+                        <b-button href="/setting-page">会社情報</b-button>
+                        <b-button href="/user-page">ユーザー</b-button>
+                        <b-button href="/category-page">カテゴリ</b-button>
+                        <b-button href="/maker-page">メーカー</b-button>
+                        <b-button href="/unit-page">単位</b-button>
+                        <b-button href="/dust-select-page">削除済み</b-button>
                     </b-col>
                     <b-col class="sm-mode">
+                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                            <b-icon icon="building"></b-icon>
+                        </b-button>
                         <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
                         </b-button>
@@ -233,7 +237,7 @@
                             <b-icon icon="folder2"></b-icon>
                         </b-button>
                         <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
+                            <b-icon icon="shop"></b-icon>
                         </b-button>
                         <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -139,16 +139,16 @@
                 </b-row>
                 <b-row v-else>
                     <b-col class="pc-mode">
-                        <b-button href="/setting-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
+                        <b-button href="/setting-page">会社情報</b-button>
+                        <b-button href="/user-page">ユーザー</b-button>
+                        <b-button href="/category-page">カテゴリ</b-button>
+                        <b-button href="/maker-page">メーカー</b-button>
+                        <b-button href="/unit-page">単位</b-button>
+                        <b-button href="/dust-select-page">削除済み</b-button>
                     </b-col>
                     <b-col class="sm-mode">
-                        <b-button href="/setting-page">
-                            <b-icon icon="chevron-left"></b-icon>
+                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                            <b-icon icon="building"></b-icon>
                         </b-button>
                         <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
@@ -157,7 +157,7 @@
                             <b-icon icon="folder2"></b-icon>
                         </b-button>
                         <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
+                            <b-icon icon="shop"></b-icon>
                         </b-button>
                         <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -179,16 +179,16 @@
                 </b-row>
                 <b-row v-else>
                     <b-col class="pc-mode">
-                        <b-button href="/setting-page">＜</b-button>
-                        <b-button href="/user-page">ユーザー登録</b-button>
-                        <b-button href="/category-page">カテゴリ登録</b-button>
-                        <b-button href="/maker-page">メーカー登録</b-button>
-                        <b-button href="/unit-page">単位登録</b-button>
-                        <b-button href="/dust-select-page">削除済み参照</b-button>
+                        <b-button href="/setting-page">会社情報</b-button>
+                        <b-button href="/user-page">ユーザー</b-button>
+                        <b-button href="/category-page">カテゴリ</b-button>
+                        <b-button href="/maker-page">メーカー</b-button>
+                        <b-button href="/unit-page">単位</b-button>
+                        <b-button href="/dust-select-page">削除済み</b-button>
                     </b-col>
                     <b-col class="sm-mode">
-                        <b-button href="/setting-page">
-                            <b-icon icon="chevron-left"></b-icon>
+                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                            <b-icon icon="building"></b-icon>
                         </b-button>
                         <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
                             <b-icon icon="person-plus-fill"></b-icon>
@@ -197,7 +197,7 @@
                             <b-icon icon="folder2"></b-icon>
                         </b-button>
                         <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="building"></b-icon>
+                            <b-icon icon="shop"></b-icon>
                         </b-button>
                         <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
                             <b-icon icon="hammer"></i>


### PR DESCRIPTION
関連Issue：設定ページのフッター戻るボタン。＜ではなく「会社情報」 #640
設定ページのフッターの文言修正 #781