### PR TITLE
見積新規・更新画面のレスポンシブ対応

### DIFF
--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -211,8 +211,8 @@
                         <b-card border-variant="white" class="mb-3 text-center" header="見積書入力"
                             header-border-variant="light">
                             <b-row>
-                                <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="顧客名"
+                                <b-col xl>
+                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="顧客名"
                                         label-for="customer" class="customer" label-align="right">
                                         <b-form-input v-model="quotation.customerName" id="customerName" size="sm"
                                             @dblclick="$bvModal.show('customer-modal')"
@@ -242,18 +242,18 @@
                                         </b-modal>
                                     </b-form-group>
                                 </b-col>
-                                <b-col sm>
+                                <b-col xl>
                                     <b-row>
-                                        <b-col sm>
-                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="敬称"
+                                        <b-col xl>
+                                            <b-form-group label-cols="2" label-cols-xl="4" label-size="sm" label="敬称"
                                                 label-for="honorificTitle" label-align="right">
                                                 <b-form-input v-model="quotation.honorificTitle" id="honorificTitle"
                                                     size="sm" autocomplete="off">
                                                 </b-form-input>
                                             </b-form-group>
                                         </b-col>
-                                        <b-col sm>
-                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="日付"
+                                        <b-col xl>
+                                            <b-form-group label-cols="2" label-cols-xl="4" label-size="sm" label="日付"
                                                 label-for="applyDate" label-align="right">
                                                 <b-form-input v-model="quotation.applyDate" id="applyDate" size="sm"
                                                     type="date">
@@ -264,17 +264,17 @@
                                 </b-col>
                             </b-row>
                             <b-row>
-                                <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
+                                <b-col xl>
+                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="部署"
                                         label-for="department" label-align="right">
                                         <b-form-input v-model="quotation.department" id="department" size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
-                                <b-col sm>
+                                <b-col xl>
                                     <b-row>
-                                        <b-col sm>
-                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="有効期限"
+                                        <b-col xl>
+                                            <b-form-group label-cols="2" label-cols-xl="4" label-size="sm" label="有効期限"
                                                 label-for="expiry" label-align="right">
                                                 <b-form-input list="list-expiry" v-model="quotation.expiry" size="sm"
                                                     autocomplete="off"></b-form-input>
@@ -283,8 +283,8 @@
                                                 </datalist>
                                             </b-form-group>
                                         </b-col>
-                                        <b-col sm>
-                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="担当者"
+                                        <b-col xl>
+                                            <b-form-group label-cols="2" label-cols-xl="4" label-size="sm" label="担当者"
                                                 label-for="manager" label-align="right">
                                                 <b-form-input v-model="quotation.manager" id="manager" size="sm"
                                                     autocomplete="off">
@@ -295,18 +295,18 @@
                                 </b-col>
                             </b-row>
                             <b-row>
-                                <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="先方担当者"
+                                <b-col xl>
+                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="先方担当者"
                                         label-for="otherPartyManager" label-align="right">
                                         <b-form-input v-model="quotation.otherPartyManager" id="otherPartyManager"
                                             size="sm">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
-                                <b-col sm>
+                                <b-col xl>
                                     <b-row>
-                                        <b-col sm>
-                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="納品期日"
+                                        <b-col xl>
+                                            <b-form-group label-cols="2" label-cols-xl="4" label-size="sm" label="納品期日"
                                                 label-for="dayOfDelivery" label-align="right">
                                                 <b-form-input list="list-dayOfDelivery"
                                                     v-model="quotation.dayOfDelivery" size="sm" autocomplete="off">
@@ -317,8 +317,8 @@
                                                 </datalist>
                                             </b-form-group>
                                         </b-col>
-                                        <b-col sm>
-                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="取引条件"
+                                        <b-col xl>
+                                            <b-form-group label-cols="2" label-cols-xl="4" label-size="sm" label="取引条件"
                                                 label-for="termOfSale" label-align="right">
                                                 <b-form-input list="list-termOfSale" v-model="quotation.termOfSale"
                                                     size="sm" autocomplete="off">
@@ -333,14 +333,14 @@
                                 </b-col>
                             </b-row>
                             <b-row>
-                                <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"
+                                <b-col xl>
+                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="件名"
                                         label-for="title" label-align="right">
                                         <b-form-input v-model="quotation.title" id="title" size="sm"></b-form-input>
                                     </b-form-group>
                                 </b-col>
-                                <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
+                                <b-col xl>
+                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="メモ"
                                         label-for="メモ" label-align="right">
                                         <b-form-textarea v-model="quotation.memo" size="sm" rows="2">
                                         </b-form-textarea>


### PR DESCRIPTION
関連Issue：見積の新規・更新画面。日付のレスポンシブが崩れる。 #744

左側のcolsを減らして右側のcolsに持って行ったがバランスがクソ悪いのでxl未満で改行するように修正。
そもそも一行に詰めすぎ事案なので、まあこれが現実的な解だろう。