### PR TITLE
表示中の請求・見積金額の合計表示機能追加

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -552,6 +552,18 @@
             <b-row class="mb-5"></b-row>
             <b-row class="mb-5"></b-row>
 
+            <!-- 表示中請求書の合計金額 -->
+            <b-card v-if="pageName=='index'" class="fixed-bottom footer">
+                <b-row>
+                    <b-col cols="8"></b-col>
+                    <b-col sm class="text-right">
+                        <b-form-group label-cols="4" label-size="sm" label="合計：" label-for="invoicesIndicateAmount">
+                            {{invoicesIndicateAmount|nf}}
+                        </b-form-group>
+                    </b-col>
+                    <b-col cols="1"></b-col>
+                </b-row>
+            </b-card>
             <!-- 更新・取消ボタンのフッター -->
             <b-card v-if="pageName=='show' || pageName=='store'" text-variant="white" class="fixed-bottom footer"
                 style="background: rgba(52,58,64,0.9);">
@@ -627,6 +639,7 @@
                     searchInvoiceWord: '',          //請求書検索
                     isInvoicesShowAll: false,               //請求書検索
                     invoicesIndicateCount: 0,       //請求書検索
+                    invoicesIndicateAmount: 0,      //一覧表示中請求書の合計金額
                     searchItemWord: '',             //商品選択モーダル検索
                     searchItemSelectCategory: '',   //商品選択モーダル検索
                     searchItemSelectMaker: '',      //商品選択モーダル検索
@@ -904,10 +917,10 @@
                         } else {
                             h.category = '請求書';
                         }
-                        h.customerName = nvl(self.invoice.customerName,'') ;
-                        h.honorificTitle = nvl(self.invoice.honorificTitle,'');
+                        h.customerName = nvl(self.invoice.customerName, '');
+                        h.honorificTitle = nvl(self.invoice.honorificTitle, '');
                         h.applyNumber = self.invoice.applyNumber;
-                        h.applyDate = nvl(self.invoice.applyDate,' / / ');
+                        h.applyDate = nvl(self.invoice.applyDate, ' / / ');
                         h.myCompanyName = self.setting.companyName;
                         h.myAddress1 = self.setting.address;
                         h.myTel1 = self.setting.telNumber;
@@ -926,11 +939,11 @@
                         };
                         pdfData = {};
                         pdfData = getPdfData();
-                        if( self.invoice.invoice_items.length > 0 ){
+                        if (self.invoice.invoice_items.length > 0) {
                             pdfData.data.bdata = self.invoice.invoice_items;
-                            pdfData.data.bdata = pdfData.data.bdata.map(i => ({ ...i, calcPrice: i.price * i.count,itemName: i.itemName.replace(/\n/g,'<br />') }));
-                        }else{
-                            pdfData.data.bdata =  [{}];
+                            pdfData.data.bdata = pdfData.data.bdata.map(i => ({ ...i, calcPrice: i.price * i.count, itemName: i.itemName.replace(/\n/g, '<br />') }));
+                        } else {
+                            pdfData.data.bdata = [{}];
                         }
                         await axios.post("/pdfmaker", pdfData)
                             .then(function (response) {
@@ -1105,11 +1118,19 @@
                     },
                     invoicesIndicateIndex: function () {
                         let invoices = this.invoices;
+                        let amount = 0;
                         if (this.isInvoicesShowAll === false)
                             invoices = invoices.filter(invoice => invoice.isPaid === false);
                         invoices = invoices.filter(invoice => searchFilter(invoice.customerName, this.searchInvoiceWord) ||
                             searchFilterDate(invoice.applyDate, this.searchInvoiceWord));
+                        let invoiceAmounts = invoices.map(
+                            invoice => invoice.invoice_items.map(
+                                item => parseInt(item.count * item.price * (invoice.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
+                        invoiceAmounts.forEach(value => {
+                            amount += value;
+                        });
                         this.invoicesIndicateCount = invoices.length;
+                        this.invoicesIndicateAmount = amount;
                         return invoices;
                     },
                     // 得意先選択モーダルの検索機能
@@ -1202,9 +1223,8 @@
             }
             // end アップロード機能
 
-            
-            function nvl(src_val, rep){
-                return (src_val == null)? rep:src_val;
+            function nvl(src_val, rep) {
+                return (src_val == null) ? rep : src_val;
             }
 
         </script>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -159,7 +159,7 @@
                           {  key: 'applyDate', label: '日付' },
                           {  key: 'customerName', label: '顧客名' },
                           {  key: 'title', label: '件名' },
-                          {  key: 'totalAmount', label: '合計金額', thClass: 'text-center', tdClass: 'text-right' },
+                          {  key: 'totalAmount', label: '請求金額', thClass: 'text-center', tdClass: 'text-right' },
                           {  key: 'numberOfAttachments', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -166,7 +166,7 @@
                           {  key: 'applyDate', label: '日付' },
                           {  key: 'customerName', label: '顧客名' },
                           {  key: 'title', label: '件名' },
-                          {  key: 'totalAmount', label: '合計金額', thClass: 'text-center', tdClass: 'text-right' },
+                          {  key: 'totalAmount', label: '見積金額', thClass: 'text-center', tdClass: 'text-right' },
                           {  key: 'numberOfAttachments', label: '' },
                         ]" :tbody-tr-class="rowClass">
                                 <template v-slot:cell(update)="data">

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -581,6 +581,18 @@
             <b-row class="mb-5"></b-row>
             <b-row class="mb-5"></b-row>
 
+            <!-- 表示中見積書の合計金額 -->
+            <b-card v-if="pageName=='index'" class="fixed-bottom footer">
+                <b-row>
+                    <b-col cols="8"></b-col>
+                    <b-col sm class="text-right">
+                        <b-form-group label-cols="4" label-size="sm" label="合計：" label-for="quotationsIndicateAmount">
+                            {{quotationsIndicateAmount|nf}}
+                        </b-form-group>
+                    </b-col>
+                    <b-col cols="1"></b-col>
+                </b-row>
+            </b-card>
             <!-- 更新・取消ボタンのフッター -->
             <b-card v-if="pageName=='show' || pageName=='store'" text-variant="white" class="fixed-bottom footer"
                 style="background: rgba(52,58,64,0.9);">
@@ -644,6 +656,7 @@
                     searchQuotationWord: '',        //請求書検索
                     quotationsShowValue: 'notConverted',    //請求書検索
                     quotationsIndicateCount: 0,     //請求書検索
+                    quotationsIndicateAmount: 0,      //一覧表示中見積書の合計金額
                     searchItemWord: '',             //商品選択モーダル検索
                     searchItemSelectCategory: '',   //商品選択モーダル検索
                     searchItemSelectMaker: '',      //商品選択モーダル検索
@@ -1090,13 +1103,21 @@
                     },
                     quotationsIndicateIndex: function () {
                         let quotations = this.quotations;
+                        let amount = 0;
                         if (this.quotationsShowValue === 'notConverted')
                             quotations = quotations.filter(quotation => quotation.isConvert === false);
                         if (this.quotationsShowValue === 'converted')
                             quotations = quotations.filter(quotation => quotation.isConvert === true);
                         quotations = quotations.filter(quotation => searchFilter(quotation.customerName, this.searchQuotationWord) ||
                             searchFilterDate(quotation.applyDate, this.searchQuotationWord));
+                        let quotationAmounts = quotations.map(
+                            quotation => quotation.quotation_items.map(
+                                item => parseInt(item.count * item.price * (quotation.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
+                        quotationAmounts.forEach(value => {
+                            amount += value;
+                        });
                         this.quotationsIndicateCount = quotations.length;
+                        this.quotationsIndicateAmount = amount;
                         return quotations;
                     },
                     // 得意先選択モーダルの検索機能


### PR DESCRIPTION
関連Issue：請求・見積一覧で合計金額を表示 #743

- 請求・見積一覧ページで、表示中の請求・見積書の合計金額をフッターに表示させる機能を追加
- 請求・見積一覧のヘッダー修正