### PR TITLE
請求・見積の端数処理を四捨五入にした

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -408,7 +408,8 @@
 
                             </template>
                             <template v-slot:cell(count)="data">
-                                <b-form-input v-model="data.item.count" type="number" size="sm" autocomplete="off">
+                                <b-form-input v-model="data.item.count" type="number" size="sm"
+                                    :formatter="formatter_count" autocomplete="off">
                                 </b-form-input>
                             </template>
                             <template v-slot:cell(unit)="data">
@@ -490,15 +491,15 @@
                                         <b-td class="text-right">消費税</b-td>
                                         <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum*0.1)|nf}}</b-td>
+                                            {{Math.round(sum*0.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum-sum/1.1)|nf}}</b-td>
+                                            {{Math.round(sum-sum/1.1)|nf}}</b-td>
                                     </b-tr>
                                     <b-tr>
                                         <b-td class="text-right">請求総額</b-td>
                                         <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount">
-                                            {{sum*1.1|nf}}</b-td>
+                                            {{Math.round(sum*1.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                     </b-tr>
                                 </b-table-simple>
@@ -1008,10 +1009,14 @@
                     formatDate(date) {
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
+                    //商品個数小数点以下切り捨て
+                    formatter_count(value) {
+                        return Math.floor(value);
+                    },
                     amountCalculation(invoice) {
                         if (!invoice.invoice_items.length) return 0;
-                        let amount = invoice.invoice_items.map(item => item.count * item.price).reduce((a, b) => a + b);
-                        if (invoice.isTaxExp === true) return Math.floor(amount * 1.1);
+                        let amount = invoice.invoice_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
+                        if (invoice.isTaxExp === true) return Math.round(amount * 1.1);
                         return amount;
                     },
                     //---- upload funcrions --
@@ -1134,7 +1139,7 @@
                     // 逐次、数量＊単価の合計をする
                     sum: function () {
                         if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
-                        return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * invoice_item.price)).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+                        return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * Math.round(invoice_item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
                     },
                     invoicesIndicateIndex: function () {
                         let invoices = this.invoices;
@@ -1143,7 +1148,7 @@
                             invoices = invoices.filter(invoice => invoice.isPaid === false);
                         let invoiceAmounts = invoices.map(
                             invoice => invoice.invoice_items.map(
-                                item => parseInt(item.count * item.price * (invoice.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
+                                item => Math.round(item.count * Math.round(item.price) * (invoice.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
                         invoiceAmounts.forEach(value => {
                             amount += value;
                         });

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -317,15 +317,15 @@
                                         <b-td class="text-right">消費税</b-td>
                                         <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum*0.1)|nf}}</b-td>
+                                            {{Math.round(sum*0.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum-sum/1.1)|nf}}</b-td>
+                                            {{Math.round(sum-sum/1.1)|nf}}</b-td>
                                     </b-tr>
                                     <b-tr>
                                         <b-td class="text-right">請求総額</b-td>
                                         <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount">
-                                            {{sum*1.1|nf}}</b-td>
+                                            {{Math.round(sum*1.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                     </b-tr>
                                 </b-table-simple>
@@ -358,7 +358,7 @@
                             <template #button-content>
                                 <i class="fas fa-print"></i>
                             </template>
-                            <b-dropdown-item @click="pdfout('delivery')" >納品書</b-dropdown-item>
+                            <b-dropdown-item @click="pdfout('delivery')">納品書</b-dropdown-item>
                         </b-dropdown>
                     </b-col>
                 </b-row>
@@ -393,7 +393,7 @@
                     invoices: [],                   //全件invoice
                     invoice: [],                    //選択中のinvoice
                     invoiceItem: [],                //選択中のinvoiceItem
-                    customer:[],
+                    customer: [],
                     setting: [],
                 },
                 methods: {
@@ -459,7 +459,7 @@
                                 console.log(response);
                                 self.setting = response.data;
                             });
-                    },                   
+                    },
                     pdfout: async function (mode) {
                         await this.getCustomer(this.invoice);
                         await this.getSetting();
@@ -483,7 +483,7 @@
                         } else {
                             pdfData.data.bdata = [{}];
                         }
-                        pdfData.defPdf.header.table_infos[0].table[0][6]= ["P","削除日付: "+this.formatDateTime(this.invoice.updatedAt),"sm_r"];
+                        pdfData.defPdf.header.table_infos[0].table[0][6] = ["P", "削除日付: " + this.formatDateTime(this.invoice.updatedAt), "sm_r"];
                         await axios.post("/pdfmaker", pdfData)
                             .then(function (response) {
                                 printJS('/pdf/' + response.data)
@@ -519,7 +519,7 @@
                     // 逐次、数量＊単価の合計をする
                     sum: function () {
                         if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
-                        return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * invoice_item.price)).reduce(function (a, b) { return a + b }, 0);
+                        return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * Math.round(invoice_item.price))).reduce(function (a, b) { return a + b }, 0);
                     },
                     invoicesIndicateIndex: function () {
                         let invoices = this.invoices;

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -444,7 +444,8 @@
 
                             </template>
                             <template v-slot:cell(count)="data">
-                                <b-form-input v-model="data.item.count" type="number" size="sm"></b-form-input>
+                                <b-form-input v-model="data.item.count" type="number" size="sm"
+                                    :formatter="formatter_count"></b-form-input>
                             </template>
                             <template v-slot:cell(unit)="data">
                                 <b-form-select v-model="data.item.unit" :options="units" size="sm"></b-form-select>
@@ -512,15 +513,15 @@
                                         <b-td class="text-right">消費税</b-td>
                                         <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum*0.1)|nf}}</b-td>
+                                            {{Math.round(sum*0.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum-sum/1.1)|nf}}</b-td>
+                                            {{Math.round(sum-sum/1.1)|nf}}</b-td>
                                     </b-tr>
                                     <b-tr>
                                         <b-td class="text-right">見積総額</b-td>
                                         <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount">
-                                            {{sum*1.1|nf}}</b-td>
+                                            {{Math.round(sum*1.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                     </b-tr>
                                 </b-table-simple>
@@ -969,10 +970,14 @@
                     formatDate(date) {
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
+                    //商品個数小数点以下切り捨て
+                    formatter_count(value) {
+                        return Math.floor(value);
+                    },
                     amountCalculation(quotation) {
                         if (!quotation.quotation_items.length) return 0;
-                        let amount = quotation.quotation_items.map(item => item.count * item.price).reduce((a, b) => a + b);
-                        if (quotation.isTaxExp === true) return Math.floor(amount * 1.1);
+                        let amount = quotation.quotation_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
+                        if (quotation.isTaxExp === true) return Math.round(amount * 1.1);
                         return amount;
                     },
                     //---- upload funcrions --
@@ -1130,7 +1135,7 @@
                     // 逐次、数量＊単価の合計をする
                     sum: function () {
                         if (typeof (this.quotation.quotation_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
-                        return this.quotation.quotation_items.map(quotation_item => parseInt(quotation_item.count * quotation_item.price)).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+                        return this.quotation.quotation_items.map(quotation_item => parseInt(quotation_item.count * Math.round(quotation_item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
                     },
                     quotationsIndicateIndex: function () {
                         let quotations = this.quotations;
@@ -1141,7 +1146,7 @@
                             quotations = quotations.filter(quotation => quotation.isConvert === true);
                         let quotationAmounts = quotations.map(
                             quotation => quotation.quotation_items.map(
-                                item => parseInt(item.count * item.price * (quotation.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
+                                item => Math.round(item.count * Math.round(item.price) * (quotation.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
                         quotationAmounts.forEach(value => {
                             amount += value;
                         });

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -307,15 +307,15 @@
                                         <b-td class="text-right">消費税</b-td>
                                         <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum*0.1)|nf}}</b-td>
+                                            {{Math.round(sum*0.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount"
                                             style="border-bottom: 2px solid white;">
-                                            {{parseInt(sum-sum/1.1)|nf}}</b-td>
+                                            {{Math.round(sum-sum/1.1)|nf}}</b-td>
                                     </b-tr>
                                     <b-tr>
                                         <b-td class="text-right">見積総額</b-td>
                                         <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount">
-                                            {{sum*1.1|nf}}</b-td>
+                                            {{Math.round(sum*1.1)|nf}}</b-td>
                                         <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                     </b-tr>
                                 </b-table-simple>
@@ -379,7 +379,7 @@
                     quotations: [],               //全件quotation
                     quotation: [],                //選択中のquotation
                     quotationItem: [],            //選択中のquotationItem
-                    customer:[],
+                    customer: [],
                     setting: [],
                 },
                 methods: {
@@ -445,12 +445,12 @@
                                 console.log(response);
                                 self.setting = response.data;
                             });
-                    },                   
+                    },
                     pdfout: async function () {
                         self = this;
                         await this.getCustomer(this.quotation);
 
-                        const pdfData = getPdfDataQuotation(this.quotation,this.setting,this.sum,this.customer);
+                        const pdfData = getPdfDataQuotation(this.quotation, this.setting, this.sum, this.customer);
                         if (!this.setting.isDisplayQuotationLogo) pdfData.defPdf.header.drawImages = [];
                         if (!this.setting.isDisplayQuotationStamp) pdfData.defPdf.footer.drawImages = [];
 
@@ -466,7 +466,7 @@
                         } else {
                             pdfData.data.bdata = [{}];
                         }
-                        pdfData.defPdf.header.table_infos[0].table[0][6]= ["P","削除日付: "+this.formatDateTime(this.quotation.updatedAt),"sm_r"];
+                        pdfData.defPdf.header.table_infos[0].table[0][6] = ["P", "削除日付: " + this.formatDateTime(this.quotation.updatedAt), "sm_r"];
                         await axios.post("/pdfmaker", pdfData)
                             .then(function (response) {
                                 printJS('/pdf/' + response.data)
@@ -502,7 +502,7 @@
                     // 逐次、数量＊単価の合計をする
                     sum: function () {
                         if (typeof (this.quotation.quotation_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
-                        return this.quotation.quotation_items.map(quotation_item => parseInt(quotation_item.count * quotation_item.price)).reduce(function (a, b) { return a + b }, 0);
+                        return this.quotation.quotation_items.map(quotation_item => parseInt(quotation_item.count * Math.round(quotation_item.price))).reduce(function (a, b) { return a + b }, 0);
                     },
                     quotationsIndicateIndex: function () {
                         let quotations = this.quotations;


### PR DESCRIPTION
関連Issue：請求・見積書の消費税計算が間違っている。消費税に関しての仕様。 #539

- 個数入力欄に小数点が入らないようにした
- 商品の金額に小数点が入力された場合、四捨五入
- 消費税処理は合計金額に対して行うようにした
- 端数処理を合計金額に対して行うようにした（合計金額から四捨五入された消費税を出しているのでいらないかも）

とりあえずこれで問題ないだろうか