### PR TITLE
消費税率フリー入力機能追加

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -307,12 +307,6 @@
                                             size="sm" autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
-                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="消費税率"
-                                        label-for="tax" label-align="right">
-                                        <b-form-input v-model="invoice.tax" id="tax" size="sm" autocomplete="off"
-                                            type="number">
-                                        </b-form-input>
-                                    </b-form-group>
                                 </b-col>
                                 <b-col xl>
                                     <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="メモ"
@@ -504,6 +498,12 @@
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
                                                 {{Math.round(sum-sum/includeTaxCoefficient(this.invoice))|nf}}</b-td>
+                                            <b-td style="padding: 8px;">
+                                                <b-input-group append="%" size="sm">
+                                                    <b-form-input v-model="invoice.tax" id="tax" size="sm">
+                                                    </b-form-input>
+                                                </b-input-group>
+                                            </b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">請求総額</b-td>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -212,8 +212,7 @@
                                 <span class="mr-2">更新日:{{formatDate(invoice.updatedAt)}}</span>
                             </b-col>
                         </b-row>
-                        <b-card border-variant="white" class="mb-3 text-center" header="請求書入力"
-                            header-border-variant="light">
+                        <b-card border-variant="white" class="text-center" header="請求書入力" header-border-variant="light">
                             <b-row>
                                 <b-col xl>
                                     <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="顧客名"

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -309,7 +309,8 @@
                                     </b-form-group>
                                     <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="消費税率"
                                         label-for="tax" label-align="right">
-                                        <b-form-input v-model="invoice.tax" id="tax" size="sm" autocomplete="off">
+                                        <b-form-input v-model="invoice.tax" id="tax" size="sm" autocomplete="off"
+                                            type="number">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -499,15 +500,15 @@
                                             <b-td class="text-right">消費税</b-td>
                                             <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum*0.1)|nf}}</b-td>
+                                                {{Math.round(sum*taxCoefficient(this.invoice))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum-sum/1.1)|nf}}</b-td>
+                                                {{Math.round(sum-sum/includeTaxCoefficient(this.invoice))|nf}}</b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">請求総額</b-td>
                                             <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount">
-                                                {{Math.round(sum*1.1)|nf}}</b-td>
+                                                {{Math.round(sum*includeTaxCoefficient(this.invoice))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                         </b-tr>
                                     </b-table-simple>
@@ -787,6 +788,7 @@
                         });
                         self.invoice = self.invoices.slice(-1)[0];
                         Vue.set(self.invoice, 'isTaxExp', true);
+                        Vue.set(self.invoice, 'tax', self.setting.defaultTax);
                         localStorage.setItem('invoice', JSON.stringify(self.invoice));
                         this.countChanged = 0;
                         this.clearFileList();
@@ -1025,8 +1027,16 @@
                     amountCalculation(invoice) {
                         if (!invoice.invoice_items.length) return 0;
                         let amount = invoice.invoice_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
-                        if (invoice.isTaxExp === true) return Math.round(amount * 1.1);
+                        if (invoice.isTaxExp === true) return Math.round(amount * this.includeTaxCoefficient(invoice));
                         return amount;
+                    },
+                    //税係数
+                    taxCoefficient: function (invoice) {
+                        return invoice.tax / 100;
+                    },
+                    //税込み係数
+                    includeTaxCoefficient: function (invoice) {
+                        return 1 + (invoice.tax / 100);
                     },
                     //---- upload funcrions --
                     async getFileListDZ() {
@@ -1157,7 +1167,7 @@
                             invoices = invoices.filter(invoice => invoice.isPaid === false);
                         let invoiceAmounts = invoices.map(
                             invoice => invoice.invoice_items.map(
-                                item => Math.round(item.count * Math.round(item.price) * (invoice.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
+                                item => Math.round(item.count * Math.round(item.price) * (invoice.isTaxExp == true ? this.includeTaxCoefficient(invoice) : 1))).reduce((a, b) => a + b));
                         invoiceAmounts.forEach(value => {
                             amount += value;
                         });

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -210,10 +210,6 @@
                             </b-row>
                             <b-row>
                                 <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="消費税率"
-                                        label-for="tax" label-align="right">
-                                        <p class="text-left pl-2" id="tax">{{invoice.tax}}</p>
-                                    </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
@@ -328,6 +324,9 @@
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
                                                 {{Math.round(sum-sum/includeTaxCoefficient(this.invoice))|nf}}</b-td>
+                                            <b-td class="text-center">
+                                                {{invoice.tax}}%
+                                            </b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">請求総額</b-td>

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -324,15 +324,15 @@
                                             <b-td class="text-right">消費税</b-td>
                                             <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum*0.1)|nf}}</b-td>
+                                                {{Math.round(sum*taxCoefficient(this.invoice))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum-sum/1.1)|nf}}</b-td>
+                                                {{Math.round(sum-sum/includeTaxCoefficient(this.invoice))|nf}}</b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">請求総額</b-td>
                                             <b-td v-if="invoice.isTaxExp" class="text-center" id="tdAmount">
-                                                {{Math.round(sum*1.1)|nf}}</b-td>
+                                                {{Math.round(sum*includeTaxCoefficient(this.invoice))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                         </b-tr>
                                     </b-table-simple>
@@ -452,6 +452,14 @@
                     },
                     formatDateTime(datetime) {
                         if (!!datetime) return moment(datetime).format("YYYY年MM月DD日 HH:mm:ss")
+                    },
+                    //税係数
+                    taxCoefficient: function (invoice) {
+                        return invoice.tax / 100;
+                    },
+                    //税込み係数
+                    includeTaxCoefficient: function (invoice) {
+                        return 1 + (invoice.tax / 100);
                     },
                     getCustomer: async function (item) {
                         self = this;

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -312,11 +312,6 @@
                                             size="sm">
                                         </b-form-input>
                                     </b-form-group>
-                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="消費税率"
-                                        label-for="tax" label-align="right">
-                                        <b-form-input v-model="quotation.tax" id="tax" size="sm" type="number">
-                                        </b-form-input>
-                                    </b-form-group>
                                 </b-col>
                                 <b-col xl>
                                     <b-row>
@@ -525,6 +520,12 @@
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
                                                 {{Math.round(sum-sum/includeTaxCoefficient(this.quotation))|nf}}</b-td>
+                                            <b-td style="padding: 8px;">
+                                                <b-input-group append="%" size="sm">
+                                                    <b-form-input v-model="quotation.tax" id="tax" size="sm">
+                                                    </b-form-input>
+                                                </b-input-group>
+                                            </b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">見積総額</b-td>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -104,6 +104,12 @@
                 padding: 0.25rem 1.25rem;
                 border-bottom: 1px solid #CED4DA;
             }
+
+            @media screen and (max-width: 1200px) {
+                #input-interval {
+                    display: none
+                }
+            }
         </style>
 
         <div id="app" v-cloak>
@@ -218,8 +224,7 @@
                                 <span class="mr-2">更新日:{{formatDate(quotation.updatedAt)}}</span>
                             </b-col>
                         </b-row>
-                        <b-card border-variant="white" class="mb-3 text-center" header="見積書入力"
-                            header-border-variant="light">
+                        <b-card border-variant="white" class="text-center" header="見積書入力" header-border-variant="light">
                             <b-row>
                                 <b-col xl>
                                     <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="顧客名"
@@ -344,23 +349,19 @@
                             </b-row>
                             <b-row>
                                 <b-col xl>
+                                    <div id="input-interval" style="height: 40px;"></div>
+                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="件名"
+                                        label-for="title" label-align="right">
+                                        <b-form-input v-model="quotation.title" id="title" size="sm">
+                                        </b-form-input>
+                                    </b-form-group>
                                 </b-col>
                                 <b-col xl>
                                     <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="メモ"
                                         label-for="メモ" label-align="right">
-                                        <b-form-textarea v-model="quotation.memo" size="sm" rows="2">
+                                        <b-form-textarea v-model="quotation.memo" size="sm" rows="3">
                                         </b-form-textarea>
                                     </b-form-group>
-                                </b-col>
-                            </b-row>
-                            <b-row>
-                                <b-col xl>
-                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="件名"
-                                        label-for="title" label-align="right">
-                                        <b-form-input v-model="quotation.title" id="title" size="sm"></b-form-input>
-                                    </b-form-group>
-                                </b-col>
-                                <b-col xl>
                                 </b-col>
                             </b-row>
                         </b-card>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -314,7 +314,7 @@
                                     </b-form-group>
                                     <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="消費税率"
                                         label-for="tax" label-align="right">
-                                        <b-form-input v-model="quotation.tax" id="tax" size="sm">
+                                        <b-form-input v-model="quotation.tax" id="tax" size="sm" type="number">
                                         </b-form-input>
                                     </b-form-group>
                                 </b-col>
@@ -521,15 +521,15 @@
                                             <b-td class="text-right">消費税</b-td>
                                             <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum*0.1)|nf}}</b-td>
+                                                {{Math.round(sum*taxCoefficient(this.quotation))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum-sum/1.1)|nf}}</b-td>
+                                                {{Math.round(sum-sum/includeTaxCoefficient(this.quotation))|nf}}</b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">見積総額</b-td>
                                             <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount">
-                                                {{Math.round(sum*1.1)|nf}}</b-td>
+                                                {{Math.round(sum*includeTaxCoefficient(this.quotation))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                         </b-tr>
                                     </b-table-simple>
@@ -803,6 +803,7 @@
                         });
                         self.quotation = self.quotations.slice(-1)[0];
                         Vue.set(self.quotation, 'isTaxExp', true);
+                        Vue.set(self.quotation, 'tax', self.setting.defaultTax);
                         localStorage.setItem('quotation', JSON.stringify(self.quotation));
                         this.countChanged = 0;
                     },
@@ -986,8 +987,16 @@
                     amountCalculation(quotation) {
                         if (!quotation.quotation_items.length) return 0;
                         let amount = quotation.quotation_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
-                        if (quotation.isTaxExp === true) return Math.round(amount * 1.1);
+                        if (quotation.isTaxExp === true) return Math.round(amount * this.includeTaxCoefficient(quotation));
                         return amount;
+                    },
+                    //税係数
+                    taxCoefficient: function (quotation) {
+                        return quotation.tax / 100;
+                    },
+                    //税込み係数
+                    includeTaxCoefficient: function (quotation) {
+                        return 1 + (quotation.tax / 100);
                     },
                     //---- upload funcrions --
                     async getFileListDZ() {
@@ -1155,7 +1164,7 @@
                             quotations = quotations.filter(quotation => quotation.isConvert === true);
                         let quotationAmounts = quotations.map(
                             quotation => quotation.quotation_items.map(
-                                item => Math.round(item.count * Math.round(item.price) * (quotation.isTaxExp == true ? 1.1 : 1))).reduce((a, b) => a + b));
+                                item => Math.round(item.count * Math.round(item.price) * (quotation.isTaxExp == true ? this.includeTaxCoefficient(quotation) : 1))).reduce((a, b) => a + b));
                         quotationAmounts.forEach(value => {
                             amount += value;
                         });

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -314,15 +314,15 @@
                                             <b-td class="text-right">消費税</b-td>
                                             <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum*0.1)|nf}}</b-td>
+                                                {{Math.round(sum*taxCoefficient(this.quotation))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
-                                                {{Math.round(sum-sum/1.1)|nf}}</b-td>
+                                                {{Math.round(sum-sum/includeTaxCoefficient(this.quotation))|nf}}</b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">見積総額</b-td>
                                             <b-td v-if="quotation.isTaxExp" class="text-center" id="tdAmount">
-                                                {{Math.round(sum*1.1)|nf}}</b-td>
+                                                {{Math.round(sum*includeTaxCoefficient(this.quotation))|nf}}</b-td>
                                             <b-td v-else class="text-center" id="tdAmount">{{sum|nf}}</b-td>
                                         </b-tr>
                                     </b-table-simple>
@@ -438,6 +438,14 @@
                     },
                     formatDateTime(datetime) {
                         if (!!datetime) return moment(datetime).format("YYYY年MM月DD日 HH:mm:ss")
+                    },
+                    //税係数
+                    taxCoefficient: function (quotation) {
+                        return quotation.tax / 100;
+                    },
+                    //税込み係数
+                    includeTaxCoefficient: function (quotation) {
+                        return 1 + (quotation.tax / 100);
                     },
                     getCustomer: async function (item) {
                         self = this;

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -208,10 +208,6 @@
                             </b-row>
                             <b-row>
                                 <b-col sm>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="消費税率"
-                                        label-for="tax" label-align="right">
-                                        <p class="text-left pl-2" id="tax">{{quotation.tax}}</p>
-                                    </b-form-group>
                                 </b-col>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
@@ -318,6 +314,9 @@
                                             <b-td v-else class="text-center" id="tdAmount"
                                                 style="border-bottom: 2px solid white;">
                                                 {{Math.round(sum-sum/includeTaxCoefficient(this.quotation))|nf}}</b-td>
+                                            <b-td class="text-center">
+                                                {{quotation.tax}}%
+                                            </b-td>
                                         </b-tr>
                                         <b-tr>
                                             <b-td class="text-right">見積総額</b-td>


### PR DESCRIPTION
関連Issue：消費税率を編集できるようにする #768

- 設定ページで設定した消費税率を請求・見積書新規作成時に自動挿入するようにした。
- 請求・見積の新規・更新画面で消費税率を編集可能にした。
- フロントページに消費税欄を追加。
- レイアウト指摘箇所修正