### PR TITLE
フロント側の税金・端数計算とPDFの計算を合わせた

### DIFF
--- a/app/static/component/def-pdf.js
+++ b/app/static/component/def-pdf.js
@@ -25,21 +25,21 @@ function getPdfDataInvoice(mode, invoice, setting, sumInvoice, customer) {
     h.customerPostNumber = customer.postNumber;
     h.customerAddress = customer.address + customer.addressSub;
     h.customerDepartment = invoice.department;
-    h.customerManager = invoice.otherPartyManager ? invoice.otherPartyManager+" 様": "";
+    h.customerManager = invoice.otherPartyManager ? invoice.otherPartyManager + " 様" : "";
     h.headerTotalLabel = "請求金額";
     sum.amountLabel = "小計";
     sum.taxLabel = "消費税";
     sum.totalLabel = "合計金額";
     if (invoice.isTaxExp) {
         sum.amount = sumInvoice;
-        sum.tax = parseInt(sumInvoice * 0.1);
-        sum.total = parseInt(sumInvoice * 1.1);
+        sum.tax = Math.round(sumInvoice * (invoice.tax / 100));
+        sum.total = Math.round(sumInvoice * (1 + invoice.tax / 100));
     } else {
         sum.taxLabel = "うち消費税";
         sum.amountLabel = "小計(税込み)";
         sum.amount = sumInvoice;
         sum.total = sumInvoice;
-        sum.tax = parseInt(sum.total - sum.total / 1.1)
+        sum.tax = Math.round(sum.total - sum.total / (1 + invoice.tax / 100));
     };
     h.memo = invoice.memo;
     h.payee = setting.payee;
@@ -47,13 +47,13 @@ function getPdfDataInvoice(mode, invoice, setting, sumInvoice, customer) {
     h.accountHolder = setting.accountHolder;
     h.logoPath = setting.logoFilePath;
     h.stampPath = setting.stampFilePath;
-    h.logoWidth = setting.logoWidth ? setting.logoWidth:50;
-    h.logoHeight = setting.logoHeight ? setting.logoHeight:50;
-    h.stampWidth = setting.stampWidth ? setting.stampWidth:50;
-    h.stampHeight = setting.stampHeight ? setting.stampHeight:50;
+    h.logoWidth = setting.logoWidth ? setting.logoWidth : 50;
+    h.logoHeight = setting.logoHeight ? setting.logoHeight : 50;
+    h.stampWidth = setting.stampWidth ? setting.stampWidth : 50;
+    h.stampHeight = setting.stampHeight ? setting.stampHeight : 50;
     return getPdfData(h, sum);
 }
-function getPdfDataQuotation( quotation, setting, sumQuotation, customer) {
+function getPdfDataQuotation(quotation, setting, sumQuotation, customer) {
     const h = {};
     const sum = {};
     h.category = '見積書';
@@ -70,23 +70,27 @@ function getPdfDataQuotation( quotation, setting, sumQuotation, customer) {
     h.customerPostNumber = customer.postNumber;
     h.customerAddress = customer.address + customer.addressSub;
     h.customerDepartment = quotation.department;
-    h.customerManager = quotation.otherPartyManager ? quotation.otherPartyManager+" 様": "";;
+    h.customerManager = quotation.otherPartyManager ? quotation.otherPartyManager + " 様" : "";;
     h.headerTotalLabel = "見積金額";
     sum.amountLabel = "小計(税込み)";
     sum.taxLabel = "うち消費税";
     sum.totalLabel = "合計金額";
     if (quotation.isTaxExp) {
         sum.amount = sumQuotation;
-        sum.tax = parseInt(sumQuotation * 0.1);
-        sum.total = parseInt(sumQuotation * 1.1);
+        sum.tax = Math.round(sumQuotation * (quotation.tax / 100));
+        sum.total = Math.round(sumQuotation * (1 + quotation.tax / 100));
     } else {
         sum.amount = sumQuotation;
         sum.total = sumQuotation;
-        sum.tax = parseInt(sum.total - sum.total / 1.1)
+        sum.tax = Math.round(sum.total - sum.total / (1 + quotation.tax / 100));
     };
     h.memo = quotation.memo;
     h.logoPath = setting.logoFilePath;
     h.stampPath = setting.stampFilePath;
+    h.logoWidth = setting.logoWidth ? setting.logoWidth : 50;
+    h.logoHeight = setting.logoHeight ? setting.logoHeight : 50;
+    h.stampWidth = setting.stampWidth ? setting.stampWidth : 50;
+    h.stampHeight = setting.stampHeight ? setting.stampHeight : 50;
     return getPdfData(h, sum);
 }
 function getPdfData(h, sum) {
@@ -110,12 +114,12 @@ function getPdfData(h, sum) {
                 "table_infos": [
                     {
                         "table": [
-                            ["", "", "", "", "", "",""],
-                            ["", "", ["P", h.customerPostNumber + "<br/>" + h.customerAddress  , "sm_l"], "", "", "", ""],
+                            ["", "", "", "", "", "", ""],
+                            ["", "", ["P", h.customerPostNumber + "<br/>" + h.customerAddress, "sm_l"], "", "", "", ""],
                             ["", "", "", "", "", "", ""],
                             ["", "", "", "", "", "", ["P", h.myCompanyName, "my_company"]],
                             ["", "", ["P", h.customerName + '&nbsp;&nbsp;' + h.honorificTitle, "client"], "", "", "", ["P", h.myAddress1, "sm_r"]],
-                            ["", "", ["P",h.customerDepartment+""+h.customerManager,"sm_l"], "", "", "", ["P", 'TEL: ' + h.myTel1, "sm_r"]],
+                            ["", "", ["P", h.customerDepartment + "" + h.customerManager, "sm_l"], "", "", "", ["P", 'TEL: ' + h.myTel1, "sm_r"]],
                             ["", "", "", "", "", "", ["P", 'FAX: ' + h.myFax1, "sm_r"]],
                         ],
                         "col_widths": ["E", "[5*mm,5*mm,88*mm,3*mm,9*mm,10*mm,70*mm]"],
@@ -156,7 +160,7 @@ function getPdfData(h, sum) {
                     }
                 ],
                 "drawImages": [
-                    ["('" + h.logoPath + "', 450,760," +h.logoWidth+ ","+h.logoHeight+",mask='auto')"]
+                    ["('" + h.logoPath + "', 450,760," + h.logoWidth + "," + h.logoHeight + ",mask='auto')"]
                 ]
             },
             "body": {
@@ -205,11 +209,11 @@ function getPdfData(h, sum) {
                 "table_infos": [
                     h.category == '請求書' ? {
                         "table": [
-                            [["P","■振込先","memo"], ["P", h.payee, "sm_l"],"",  ""],
-                            ["",["P","カナ","sm_r"],["P", h.accountHolderKana, "sm_l"],""],
-                            ["",["P","名義","sm_r"],["P", h.accountHolder, "sm_l"],""],
-                            ["","","","",],
-                            [["P","■備考","memo"],["P", h.memo, "sm_l"],"",""],
+                            [["P", "■振込先", "memo"], ["P", h.payee, "sm_l"], "", ""],
+                            ["", ["P", "カナ", "sm_r"], ["P", h.accountHolderKana, "sm_l"], ""],
+                            ["", ["P", "名義", "sm_r"], ["P", h.accountHolder, "sm_l"], ""],
+                            ["", "", "", "",],
+                            [["P", "■備考", "memo"], ["P", h.memo, "sm_l"], "", ""],
                         ],
                         "col_widths": ["E", "(20*mm,15*mm,90*mm,5*mm)"],
                         "row_heights": ["E", "(6*mm,6*mm,6*mm,4*mm,25*mm)"],
@@ -219,23 +223,23 @@ function getPdfData(h, sum) {
                             ["E", "('SPAN',(1,0),(2,0))"],
                             ["E", "('SPAN',(1,4),(2,4))"],
                         ]
-                    } 
-                    :{
-                        "table": [
-                            [["P","■備考","memo"], ["P", h.memo, "sm_l"], "", ""],
-                            ["", "", "", ""],
-                        ],
-                        "col_widths": ["E", "(15*mm,150*mm,5*mm,5*mm)"],
-                        "row_heights": ["E", "(40*mm,5*mm)"],
-                        "table_style": [
-                            ["NOP", "('GRID', (0, 0), (-1,-1), 0.25, colors.black)"],
-                            ["E", "('FONT', (0, 0), (-1, -1), 'IPAexGothic', 11)"],
-                            ["E", "('VALIGN',(0,0),(-1,-1),'TOP')"],
-                        ]
                     }
+                        : {
+                            "table": [
+                                [["P", "■備考", "memo"], ["P", h.memo, "sm_l"], "", ""],
+                                ["", "", "", ""],
+                            ],
+                            "col_widths": ["E", "(15*mm,150*mm,5*mm,5*mm)"],
+                            "row_heights": ["E", "(40*mm,5*mm)"],
+                            "table_style": [
+                                ["NOP", "('GRID', (0, 0), (-1,-1), 0.25, colors.black)"],
+                                ["E", "('FONT', (0, 0), (-1, -1), 'IPAexGothic', 11)"],
+                                ["E", "('VALIGN',(0,0),(-1,-1),'TOP')"],
+                            ]
+                        }
                 ],
                 "drawImages": [
-                    ["('" + h.stampPath + "', 510,720,"+h.stampWidth+ ","+h.stampHeight+",mask='auto')"]
+                    ["('" + h.stampPath + "', 510,720," + h.stampWidth + "," + h.stampHeight + ",mask='auto')"]
                 ]
             }
         },
@@ -307,12 +311,12 @@ function getPdfDataRcpt(invoice, setting, sum) {
 
     if (invoice.isTaxExp) {
         sumr.amount = sum
-        sumr.tax = parseInt(sum * 0.1);
-        sumr.total = parseInt(sum * 1.1);
+        sumr.tax = Math.round(sum * (invoice.tax / 100));
+        sumr.total = Math.round(sum * (1 + invoice.tax / 100));
     } else {
         sumr.amount = sum;
         sumr.total = sum;
-        sumr.tax = parseInt(sum.total - sum.total / 1.1)
+        sumr.tax = Math.round(sum.total - sum.total / (1 + invoice.tax / 100));
     };
 
     return {


### PR DESCRIPTION
- 消費税率フリー入力機能追加 #892　請求・見積の端数処理を四捨五入にした #881　で請求・見積計算ロジックに変更があったので、それをPDF側も対応させた。
- 見積書印刷時にエラーが出たのでその対応